### PR TITLE
Ensure Docker + automated testing enviornments match

### DIFF
--- a/.github/workflows/ALL-PHPUnit.yml
+++ b/.github/workflows/ALL-PHPUnit.yml
@@ -4,7 +4,7 @@ on: [push]
 
 env:
   PKG_NAME: TripalCultivate-Genetics
-  MODULES: "trpcultivate_genetics"
+  MODULES: "trpcultivate_genetics trpcultivate_genotypes trpcultivate_genomatrix trpcultivate_qtl trpcultivate_vcf"
 
 jobs:
   run-tests:

--- a/.github/workflows/ALL-testCoverage-codeclimate.yml
+++ b/.github/workflows/ALL-testCoverage-codeclimate.yml
@@ -4,7 +4,7 @@ on: [push]
 
 env:
   PKG_NAME: TripalCultivate-Genetics
-  MODULES: "trpcultivate_genetics"
+  MODULES: "trpcultivate_genetics trpcultivate_genotypes trpcultivate_genomatrix trpcultivate_qtl trpcultivate_vcf"
   IMAGE_TAG: drupal9.5.x-dev-php8.1-pgsql13
   SIMPLETEST_BASE_URL: "http://localhost"
   SIMPLETEST_DB: "pgsql://drupaladmin:drupal9developmentonlylocal@localhost/sitedb"

--- a/.github/workflows/MAIN-phpunit-Grid1A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1A.yml
@@ -14,7 +14,7 @@ jobs:
         uses: tripal/test-tripal-action@v1.0
         with:
           directory-name: 'TripalCultivate-Genetics'
-          modules: 'trpcultivate_genetics'
+          modules: 'trpcultivate_genetics trpcultivate_genotypes trpcultivate_genomatrix trpcultivate_qtl trpcultivate_vcf'
           php-version: '8.0'
           pgsql-version: '13'
           drupal-version: '9.3.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid1B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1B.yml
@@ -14,7 +14,7 @@ jobs:
         uses: tripal/test-tripal-action@v1.0
         with:
           directory-name: 'TripalCultivate-Genetics'
-          modules: 'trpcultivate_genetics'
+          modules: 'trpcultivate_genetics trpcultivate_genotypes trpcultivate_genomatrix trpcultivate_qtl trpcultivate_vcf'
           php-version: '8.0'
           pgsql-version: '13'
           drupal-version: '9.4.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid1C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1C.yml
@@ -14,7 +14,7 @@ jobs:
         uses: tripal/test-tripal-action@v1.0
         with:
           directory-name: 'TripalCultivate-Genetics'
-          modules: 'trpcultivate_genetics'
+          modules: 'trpcultivate_genetics trpcultivate_genotypes trpcultivate_genomatrix trpcultivate_qtl trpcultivate_vcf'
           php-version: '8.0'
           pgsql-version: '13'
           drupal-version: '9.5.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid2A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2A.yml
@@ -14,7 +14,7 @@ jobs:
         uses: tripal/test-tripal-action@v1.0
         with:
           directory-name: 'TripalCultivate-Genetics'
-          modules: 'trpcultivate_genetics'
+          modules: 'trpcultivate_genetics trpcultivate_genotypes trpcultivate_genomatrix trpcultivate_qtl trpcultivate_vcf'
           php-version: '8.1'
           pgsql-version: '13'
           drupal-version: '9.3.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid2B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2B.yml
@@ -14,7 +14,7 @@ jobs:
         uses: tripal/test-tripal-action@v1.0
         with:
           directory-name: 'TripalCultivate-Genetics'
-          modules: 'trpcultivate_genetics'
+          modules: 'trpcultivate_genetics trpcultivate_genotypes trpcultivate_genomatrix trpcultivate_qtl trpcultivate_vcf'
           php-version: '8.1'
           pgsql-version: '13'
           drupal-version: '9.4.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid2C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2C.yml
@@ -14,7 +14,7 @@ jobs:
         uses: tripal/test-tripal-action@v1.0
         with:
           directory-name: 'TripalCultivate-Genetics'
-          modules: 'trpcultivate_genetics'
+          modules: 'trpcultivate_genetics trpcultivate_genotypes trpcultivate_genomatrix trpcultivate_qtl trpcultivate_vcf'
           php-version: '8.1'
           pgsql-version: '13'
           drupal-version: '9.5.x-dev'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 FROM tripalproject/tripaldocker:latest
-MAINTAINER Lacey-Anne Sanderson <lacey.sanderson@usask.ca>
 
-COPY . /var/www/drupal9/web/modules/TripalCultivate-Genetics
+COPY . /var/www/drupal9/web/modules/contrib/TripalCultivate-Genetics
 
-WORKDIR /var/www/drupal9/web/modules/TripalCultivate-Genetics
+WORKDIR /var/www/drupal9/web/modules/contrib/TripalCultivate-Genetics
 
-## RUN service postgresql restart \
-##  && drush en trpcultivate_genetics --yes
+RUN service postgresql restart \
+  && drush en trpcultivate_genetics trpcultivate_genotypes trpcultivate_genomatrix trpcultivate_qtl trpcultivate_vcf --yes


### PR DESCRIPTION
This PR updates the dockerfile and automated testing workflows to ensure all modules are enabled by default and that the module path matches.

You can start a development focused docker container as follows:

1. Clone this repository.
2. Create a new branch or checkout an existing one specific to your task.
3. Build the docker image and create a container to develop in.
4. Execute the following from within your cloned repo directory.

```
docker build --tag=trpcultivate:latest .
docker run --publish=80:80 --name=trpcultivate -tid --volume=`pwd`:/var/www/drupal9/web/modules/contrib/TripalCultivate-Genetics trpcultivate:latest
docker exec trpcultivate service postgresql restart
```

Login and container setup match the [TripalDocker development setup described in the official Tripal documentation](https://tripaldoc.readthedocs.io/en/latest/install/docker.html#development-site-information).

You can run phpunit as follows:
```
docker exec -it trpcultivate phpunit
```