### PR TITLE
Update testing grid to include Drupal 10.0 and 10.1 + PHP 8.2

### DIFF
--- a/.github/workflows/ALL-PHPUnit.yml
+++ b/.github/workflows/ALL-PHPUnit.yml
@@ -16,17 +16,27 @@ jobs:
         php-version:
           - "8.0"
           - "8.1"
+          - "8.2"
         pgsql-version:
           - "13"
         drupal-version:
-          - "9.3.x-dev"
           - "9.4.x-dev"
           - "9.5.x-dev"
-          # - "10.0.x-dev"
-#        exclude:
-#          - php-version: "8.0"
-#            pgsql-version: "13"
-#            drupal-version: "10.0.x-dev"
+          - "10.0.x-dev"
+          - "10.1.x-dev"
+        exclude:
+          - php-version: "8.2"
+            pgsql-version: "13"
+            drupal-version: "9.4.x-dev"
+          - php-version: "8.2"
+            pgsql-version: "13"
+            drupal-version: "9.5.x-dev"
+          - php-version: "8.0"
+            pgsql-version: "13"
+            drupal-version: "10.0.x-dev"
+          - php-version: "8.0"
+            pgsql-version: "13"
+            drupal-version: "10.1.x-dev"
 
     steps:
       # Check out the repo

--- a/.github/workflows/MAIN-phpunit-Grid1A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1A.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - 4.x
-      - customize-template
+      - g5.18-updateTestingGrid
 jobs:
   run-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/MAIN-phpunit-Grid1A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1A.yml
@@ -17,4 +17,4 @@ jobs:
           modules: 'trpcultivate_genetics trpcultivate_genotypes trpcultivate_genomatrix trpcultivate_qtl trpcultivate_vcf'
           php-version: '8.0'
           pgsql-version: '13'
-          drupal-version: '9.3.x-dev'
+          drupal-version: '9.4.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid1B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1B.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - 4.x
-      - customize-template
+      - g5.18-updateTestingGrid
 jobs:
   run-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/MAIN-phpunit-Grid1B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1B.yml
@@ -17,4 +17,4 @@ jobs:
           modules: 'trpcultivate_genetics trpcultivate_genotypes trpcultivate_genomatrix trpcultivate_qtl trpcultivate_vcf'
           php-version: '8.0'
           pgsql-version: '13'
-          drupal-version: '9.4.x-dev'
+          drupal-version: '9.5.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid2A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2A.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - 4.x
-      - customize-template
+      - g5.18-updateTestingGrid
 jobs:
   run-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/MAIN-phpunit-Grid2A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2A.yml
@@ -17,4 +17,4 @@ jobs:
           modules: 'trpcultivate_genetics trpcultivate_genotypes trpcultivate_genomatrix trpcultivate_qtl trpcultivate_vcf'
           php-version: '8.1'
           pgsql-version: '13'
-          drupal-version: '9.3.x-dev'
+          drupal-version: '9.4.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid2B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2B.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - 4.x
-      - customize-template
+      - g5.18-updateTestingGrid
 jobs:
   run-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/MAIN-phpunit-Grid2B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2B.yml
@@ -17,4 +17,4 @@ jobs:
           modules: 'trpcultivate_genetics trpcultivate_genotypes trpcultivate_genomatrix trpcultivate_qtl trpcultivate_vcf'
           php-version: '8.1'
           pgsql-version: '13'
-          drupal-version: '9.4.x-dev'
+          drupal-version: '9.5.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid2C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2C.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - 4.x
-      - customize-template
+      - g5.18-updateTestingGrid
 jobs:
   run-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/MAIN-phpunit-Grid2D.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2D.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - 4.x
-      - customize-template
+      - g5.18-updateTestingGrid
 jobs:
   run-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/MAIN-phpunit-Grid2D.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2D.yml
@@ -17,4 +17,4 @@ jobs:
           modules: 'trpcultivate_genetics trpcultivate_genotypes trpcultivate_genomatrix trpcultivate_qtl trpcultivate_vcf'
           php-version: '8.1'
           pgsql-version: '13'
-          drupal-version: '10.0.x-dev'
+          drupal-version: '10.1.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid3C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3C.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - 4.x
-      - customize-template
+      - g5.18-updateTestingGrid
 jobs:
   run-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/MAIN-phpunit-Grid3C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3C.yml
@@ -15,6 +15,6 @@ jobs:
         with:
           directory-name: 'TripalCultivate-Genetics'
           modules: 'trpcultivate_genetics trpcultivate_genotypes trpcultivate_genomatrix trpcultivate_qtl trpcultivate_vcf'
-          php-version: '8.1'
+          php-version: '8.2'
           pgsql-version: '13'
           drupal-version: '10.0.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid3D.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3D.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - 4.x
-      - customize-template
+      - g5.18-updateTestingGrid
 jobs:
   run-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/MAIN-phpunit-Grid3D.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3D.yml
@@ -15,6 +15,6 @@ jobs:
         with:
           directory-name: 'TripalCultivate-Genetics'
           modules: 'trpcultivate_genetics trpcultivate_genotypes trpcultivate_genomatrix trpcultivate_qtl trpcultivate_vcf'
-          php-version: '8.0'
+          php-version: '8.2'
           pgsql-version: '13'
-          drupal-version: '9.5.x-dev'
+          drupal-version: '10.1.x-dev'

--- a/README.md
+++ b/README.md
@@ -59,10 +59,11 @@ maintainability issues and test coverage.
 
 The following compatibility is proven via automated testing workflows.
 
-| Drupal | 9.3.x | 9.4.x | 9.5.x | 10.0.x |
-|--------|-------|-------|-------|--------|
-| **PHP 8.0** | ![Grid1A-Badge] | ![Grid1B-Badge] | ![Grid1C-Badge] |  |
-| **PHP 8.1** | ![Grid2A-Badge] | ![Grid2B-Badge] | ![Grid2C-Badge] |  |
+| Drupal      | 9.4.x           | 9.5.x           | 10.0.x          | 10.1.x          |
+|-------------|-----------------|-----------------|-----------------|-----------------|
+| **PHP 8.0** | ![Grid1A-Badge] | ![Grid1B-Badge] |                 |                 |
+| **PHP 8.1** | ![Grid2A-Badge] | ![Grid2B-Badge] | ![Grid2C-Badge] | ![Grid2D-Badge] |
+| **PHP 8.2** |                 |                 | ![Grid3C-Badge] | ![Grid3D-Badge] |
 
 [our CodeClimate project page]: https://github.com/TripalCultivate/TripalCultivate-Genetics
 [MaintainabilityBadge]: https://api.codeclimate.com/v1/badges/fddbd06df5e320f09cd9/maintainability
@@ -70,9 +71,11 @@ The following compatibility is proven via automated testing workflows.
 
 [Grid1A-Badge]: https://github.com/TripalCultivate/TripalCultivate-Genetics/actions/workflows/MAIN-phpunit-Grid1A.yml/badge.svg
 [Grid1B-Badge]: https://github.com/TripalCultivate/TripalCultivate-Genetics/actions/workflows/MAIN-phpunit-Grid1B.yml/badge.svg
-[Grid1C-Badge]: https://github.com/TripalCultivate/TripalCultivate-Genetics/actions/workflows/MAIN-phpunit-Grid1C.yml/badge.svg
 
 [Grid2A-Badge]: https://github.com/TripalCultivate/TripalCultivate-Genetics/actions/workflows/MAIN-phpunit-Grid2A.yml/badge.svg
 [Grid2B-Badge]: https://github.com/TripalCultivate/TripalCultivate-Genetics/actions/workflows/MAIN-phpunit-Grid2B.yml/badge.svg
 [Grid2C-Badge]: https://github.com/TripalCultivate/TripalCultivate-Genetics/actions/workflows/MAIN-phpunit-Grid2C.yml/badge.svg
 [Grid2D-Badge]: https://github.com/TripalCultivate/TripalCultivate-Genetics/actions/workflows/MAIN-phpunit-Grid2D.yml/badge.svg
+
+[Grid3C-Badge]: https://github.com/TripalCultivate/TripalCultivate-Genetics/actions/workflows/MAIN-phpunit-Grid3C.yml/badge.svg
+[Grid3D-Badge]: https://github.com/TripalCultivate/TripalCultivate-Genetics/actions/workflows/MAIN-phpunit-Grid3D.yml/badge.svg

--- a/trpcultivate_genetics/tests/src/Functional/InstallTest.php
+++ b/trpcultivate_genetics/tests/src/Functional/InstallTest.php
@@ -13,7 +13,7 @@ use Drupal\Tests\tripal_chado\Functional\ChadoTestBrowserBase;
  */
 class InstallTest extends ChadoTestBrowserBase {
 
-  protected $defaultTheme = 'stable';
+  protected $defaultTheme = 'stark';
 
   /**
    * Modules to enable.

--- a/trpcultivate_genomatrix/tests/src/Functional/InstallTest.php
+++ b/trpcultivate_genomatrix/tests/src/Functional/InstallTest.php
@@ -13,7 +13,7 @@ use Drupal\Tests\tripal_chado\Functional\ChadoTestBrowserBase;
  */
 class InstallTest extends ChadoTestBrowserBase {
 
-  protected $defaultTheme = 'stable';
+  protected $defaultTheme = 'stark';
 
   /**
    * Modules to enable.

--- a/trpcultivate_genotypes/tests/src/Functional/GenotypesLoader/GenotypesLoaderBasePluginTest.php
+++ b/trpcultivate_genotypes/tests/src/Functional/GenotypesLoader/GenotypesLoaderBasePluginTest.php
@@ -16,7 +16,7 @@ use Drupal\trpcultivate_genotypes\GenotypesLoader\GenotypesLoaderInterface;
  */
 class GenotypesLoaderBasePluginTest extends ChadoTestBrowserBase {
 
-  protected $defaultTheme = 'stable';
+  protected $defaultTheme = 'stark';
 
   /**
    * Modules to enable.
@@ -27,7 +27,7 @@ class GenotypesLoaderBasePluginTest extends ChadoTestBrowserBase {
 
   /**
    * Test a fake instance of Genotypes Loader Plugin.
-   * 
+   *
    * @group GenotypesLoader
    */
   public function testGenotypesLoaderPluginBase(){
@@ -106,7 +106,7 @@ class GenotypesLoaderBasePluginTest extends ChadoTestBrowserBase {
     // Set method for Variant Subtype ID
     $success = $plugin->setVariantSubTypeID($variant_cvterm_id);
     $this->assertTrue($success, "Unable to set cvterm_id for variant subtype");
-    
+
     // Get method for Variant Subtype ID
     $grabbed_variant_cvterm_id = $plugin->getVariantSubTypeID();
     $this->assertEquals($variant_cvterm_id, $grabbed_variant_cvterm_id, "The variant_cvterm_id using the getter method does not match.");
@@ -117,14 +117,14 @@ class GenotypesLoaderBasePluginTest extends ChadoTestBrowserBase {
     // Set method for Marker Subtype ID
     $success = $plugin->setMarkerSubTypeID($marker_cvterm_id);
     $this->assertTrue($success, "Unable to set cvterm_id for marker subtype");
-    
+
     // Get method for Marker Subtype ID
     $grabbed_marker_cvterm_id = $plugin->getMarkerSubTypeID();
     $this->assertEquals($marker_cvterm_id, $grabbed_marker_cvterm_id, "The marker_cvterm_id using the getter method does not match.");
 
     // Assign the file type of the input file
     $input_file_type = 'vcf';
-    
+
     // Set method for input file type
     $success = $plugin->setInputFileType($input_file_type);
     $this->assertTrue($success, "Unable to set file type for the input file");

--- a/trpcultivate_genotypes/tests/src/Functional/GenotypesLoader/GenotypesLoaderPluginManagerTest.php
+++ b/trpcultivate_genotypes/tests/src/Functional/GenotypesLoader/GenotypesLoaderPluginManagerTest.php
@@ -16,7 +16,7 @@ use Drupal\trpcultivate_genotypes\Plugin\GenotypesLoader\VCFGenotypesLoader;
  */
 class GenotypesLoaderPluginManagerTest extends ChadoTestBrowserBase {
 
-  protected $defaultTheme = 'stable';
+  protected $defaultTheme = 'stark';
 
   /**
    * Modules to enable.
@@ -27,11 +27,11 @@ class GenotypesLoaderPluginManagerTest extends ChadoTestBrowserBase {
 
   /**
    * Test a fake instance of Genotypes Loader Plugin.
-   * 
+   *
    * @group GenotypesLoader
    */
   public function testGenotypesLoaderPluginManager(){
-    
+
     // Ensure we see all logging in tests.
     \Drupal::state()->set('is_a_test_environment', TRUE);
 
@@ -101,7 +101,7 @@ class GenotypesLoaderPluginManagerTest extends ChadoTestBrowserBase {
     $exception_caught = false;
     try {
       $new_plugin = $plugin_manager->setParameters($options);
-    } 
+    }
     catch ( \Exception $e ) {
       $exception_caught = true;
     }

--- a/trpcultivate_genotypes/tests/src/Functional/InstallTest.php
+++ b/trpcultivate_genotypes/tests/src/Functional/InstallTest.php
@@ -13,7 +13,7 @@ use Drupal\Tests\tripal_chado\Functional\ChadoTestBrowserBase;
  */
 class InstallTest extends ChadoTestBrowserBase {
 
-  protected $defaultTheme = 'stable';
+  protected $defaultTheme = 'stark';
 
   /**
    * Modules to enable.

--- a/trpcultivate_qtl/tests/src/Functional/InstallTest.php
+++ b/trpcultivate_qtl/tests/src/Functional/InstallTest.php
@@ -13,7 +13,7 @@ use Drupal\Tests\tripal_chado\Functional\ChadoTestBrowserBase;
  */
 class InstallTest extends ChadoTestBrowserBase {
 
-  protected $defaultTheme = 'stable';
+  protected $defaultTheme = 'stark';
 
   /**
    * Modules to enable.

--- a/trpcultivate_vcf/tests/src/Functional/InstallTest.php
+++ b/trpcultivate_vcf/tests/src/Functional/InstallTest.php
@@ -13,7 +13,7 @@ use Drupal\Tests\tripal_chado\Functional\ChadoTestBrowserBase;
  */
 class InstallTest extends ChadoTestBrowserBase {
 
-  protected $defaultTheme = 'stable';
+  protected $defaultTheme = 'stark';
 
   /**
    * Modules to enable.


### PR DESCRIPTION
Issue #18 

## Description

This PR adds Drupal 10.0 + 10.1 and PHP 8.2 to our automated testing. This ensures we are keeping up with Drupal compatibility and matches the recent change in testing in Tripal Core.

## Testing

No manual testing is needed of this PR. Rather we just want to ensure the additional tests are run and their status is displayed on the README.