### PR TITLE
G4.17 insert or select record genotypes loader

### DIFF
--- a/trpcultivate_genotypes/src/GenotypesLoader/GenotypesLoaderInterface.php
+++ b/trpcultivate_genotypes/src/GenotypesLoader/GenotypesLoaderInterface.php
@@ -15,6 +15,40 @@ interface GenotypesLoaderInterface {
    */
   public function label();
 
+  /**
+   * Given a record, selects it from the chado database (or inserts if not found
+   * and the mode allows) and returns the primary key.
+   * 
+   * @param string $record_type
+   *   A human-readable term for your record, used for error messages.
+   *   Eg. "Genotype", "Marker", "Genotype Marker Link"
+   * @param string $table
+   *   The name of the chado table to select from and/or insert into.
+   * @param int $mode
+   *   The user-specified means in which we are allowed to get the record's 
+   *   primary key. 
+   *   For example, the user may prefer to add stocks to the database
+   *   manually or expects all of them to exist, so chooses a mode of 0 (select 
+   *   only) so they will be informed if a germplasm does not already exist by
+   *   an error.
+   *   This must be one of: 0 (Select Only), 1 (Insert Only), 2 (Insert & Select)
+   * @param array $select_values
+   *   An array of [table column] => [value] mappings. 
+   *   These values will be used for both the select and the insert, but are 
+   *   specific to selecting the right record and thus are used in the 
+   *   conditions (i.e. WHERE clause) of the query.
+   * @param array $insert_values
+   *   An array of [table column] => [value] mappings that is specific to the 
+   *   insert. This is not required if mode is select only, and will be combined 
+   *   with select values for an insert. More specifically, the values for all 
+   *   columns set in the new record are defined in the combined select + insert
+   *   values arrays.
+   * @return int|false
+   *   The value of the primary key for the inserted/selected record.
+   *   If no primary key can be retrieved, then FALSE will be returned.
+   */
+  public function getRecordPkey(string $record_type, string $table, int $mode, array $select_values, array $insert_values = []);
+
   /****************************************************************************
    *  Setter functions
    ****************************************************************************/
@@ -135,43 +169,5 @@ interface GenotypesLoaderInterface {
    *   The filepath
    */ 
   public function getSampleFilepath();
-
-  /****************************************************************************
-   *  Other functions
-   ****************************************************************************/
-
-  /**
-   * Given a record, selects it from the chado database (or inserts if not found
-   * and the mode allows) and returns the primary key.
-   * 
-   * @param string $record_type
-   *   A human-readable term for your record, used for error messages.
-   *   Eg. "Genotype", "Marker", "Genotype Marker Link"
-   * @param string $table
-   *   The name of the chado table to select from and/or insert into.
-   * @param int $mode
-   *   The user-specified means in which we are allowed to get the record's 
-   *   primary key. 
-   *   For example, the user may prefer to add stocks to the database
-   *   manually or expects all of them to exist, so chooses a mode of 0 (select 
-   *   only) so they will be informed if a germplasm does not already exist by
-   *   an error.
-   *   This must be one of: 0 (Select Only), 1 (Insert Only), 2 (Insert & Select)
-   * @param array $select_values
-   *   An array of [table column] => [value] mappings. 
-   *   These values will be used for both the select and the insert, but are 
-   *   specific to selecting the right record and thus are used in the 
-   *   conditions (i.e. WHERE clause) of the query.
-   * @param array $insert_values
-   *   An array of [table column] => [value] mappings that is specific to the 
-   *   insert. This is not required if mode is select only, and will be combined 
-   *   with select values for an insert. More specifically, the values for all 
-   *   columns set in the new record are defined in the combined select + insert
-   *   values arrays.
-   * @return int|false
-   *   The value of the primary key for the inserted/selected record.
-   *   If no primary key can be retrieved, then FALSE will be returned.
-   */
-  public function getRecordPkey(string $record_type, string $table, int $mode, array $select_values, array $insert_values = []);
   
 }

--- a/trpcultivate_genotypes/src/GenotypesLoader/GenotypesLoaderInterface.php
+++ b/trpcultivate_genotypes/src/GenotypesLoader/GenotypesLoaderInterface.php
@@ -136,4 +136,39 @@ interface GenotypesLoaderInterface {
    */ 
   public function getSampleFilepath();
 
+  /****************************************************************************
+   *  Other functions
+   ****************************************************************************/
+
+  /**
+   * Given a record, selects it from the chado database (or inserts if not found
+   * and the mode allows) and returns the primary key.
+   * 
+   * @param string $record_type
+   *   A human-readable term for your record, used for error messages.
+   *   Eg. "Genotype", "Marker", "Genotype Marker Link"
+   * @param string $table
+   *   The name of the chado table to select from and/or insert into.
+   * @param int $mode
+   *   The user-specified means in which we are allowed to get the record's 
+   *   primary key. 
+   *   For example, the user may prefer to add stocks to the database
+   *   manually or expects all of them to exist, so chooses a mode of 0 (select 
+   *   only) so they will be informed if a germplasm does not already exist by
+   *   an error.
+   *   This must be one of: 0 (Select Only), 1 (Insert Only), 2 (Insert & Select)
+   * @param array $select_values
+   *   An array of [table column] => [value] mappings. 
+   *   These values will be used for both the select and the insert, but are 
+   *   specific to selecting the right record.
+   * @param array $insert_values
+   *   An array of [table column] => [value] mappings that is specific to the 
+   *   insert. This is not required if mode is select only, and will be combined 
+   *   with select values for an insert.
+   * @return int|false
+   *   The value of the primary key for the inserted/selected record.
+   *   If no primary key can be retrieved, then FALSE will be returned.
+   */
+  public function getRecordPkey(string $record_type, string $table, int $mode, array $select_values, array $insert_values = []);
+  
 }

--- a/trpcultivate_genotypes/src/GenotypesLoader/GenotypesLoaderInterface.php
+++ b/trpcultivate_genotypes/src/GenotypesLoader/GenotypesLoaderInterface.php
@@ -160,11 +160,14 @@ interface GenotypesLoaderInterface {
    * @param array $select_values
    *   An array of [table column] => [value] mappings. 
    *   These values will be used for both the select and the insert, but are 
-   *   specific to selecting the right record.
+   *   specific to selecting the right record and thus are used in the 
+   *   conditions (i.e. WHERE clause) of the query.
    * @param array $insert_values
    *   An array of [table column] => [value] mappings that is specific to the 
    *   insert. This is not required if mode is select only, and will be combined 
-   *   with select values for an insert.
+   *   with select values for an insert. More specifically, the values for all 
+   *   columns set in the new record are defined in the combined select + insert
+   *   values arrays.
    * @return int|false
    *   The value of the primary key for the inserted/selected record.
    *   If no primary key can be retrieved, then FALSE will be returned.

--- a/trpcultivate_genotypes/src/GenotypesLoader/GenotypesLoaderPluginBase.php
+++ b/trpcultivate_genotypes/src/GenotypesLoader/GenotypesLoaderPluginBase.php
@@ -371,7 +371,7 @@ abstract class GenotypesLoaderPluginBase extends PluginBase implements Genotypes
 
     if (!in_array($mode, $valid_modes)) {
       throw new \Exception(
-        t("The specified mode is not valid. (mode=@mode)." , ['@mode'=>$mode])
+        t("The specified mode is not valid (mode=@mode)." , ['@mode'=>$mode])
       );
       return FALSE;
     }
@@ -396,7 +396,7 @@ abstract class GenotypesLoaderPluginBase extends PluginBase implements Genotypes
     }
     $record = $query->execute()->fetchAll();
 
-    // If it exists and the mode is 1 (Insert Only), then return an error to drush.
+    // If it exists and the mode is 1 (Insert Only), then throw an exception.
     if (sizeof($record) == 1) {
       if ($mode == $insert_only) {
         throw new \Exception(
@@ -414,12 +414,12 @@ abstract class GenotypesLoaderPluginBase extends PluginBase implements Genotypes
     // error to the user - not just run with the first one.
     elseif (sizeof($record) > 1) {
       throw new \Exception(
-        t("Record '@record_type' is not unique. (mode=@mode). Values: " .print_r($select_values, TRUE), ['@record_type'=>$record_type, '@mode'=>$mode])
+        t("Record '@record_type' is not unique (mode=@mode). Values: " .print_r($select_values, TRUE), ['@record_type'=>$record_type, '@mode'=>$mode])
       );
       return FALSE;
     }
 
-    // If there is no pre-existing sample but we've been given permission to create it,
+    // If there is no pre-existing record but we've been given permission to create it,
     // then insert it
     elseif ($mode != $select_only) {
 

--- a/trpcultivate_genotypes/src/GenotypesLoader/GenotypesLoaderPluginBase.php
+++ b/trpcultivate_genotypes/src/GenotypesLoader/GenotypesLoaderPluginBase.php
@@ -136,6 +136,94 @@ abstract class GenotypesLoaderPluginBase extends PluginBase implements Genotypes
     return (string) $this->pluginDefinition['label'];
   }
 
+  /**
+    * {@inheritdoc}
+    */
+  public function getRecordPkey(string $record_type, string $table, int $mode, array $select_values, array $insert_values = []) {
+    
+    // Check if the mode is one of the 3 options, throw an exception otherwise 
+    $valid_modes = [0, 1, 2];
+
+    if (!in_array($mode, $valid_modes)) {
+      throw new \Exception(
+        t("The specified mode is not valid (mode=@mode)." , ['@mode'=>$mode])
+      );
+      return FALSE;
+    }
+
+    // Set some variables to abstract mode
+    $select_only = 0;
+    $insert_only = 1;
+    $both = 2;
+
+    // the name of the primary key.
+    $pkey = $table . '_id';
+
+    // First we select the record to see if it already exists.
+    $query = $this->connection->select('1:' . $table, 't');
+    $query->fields('t', [$pkey]);
+    // Iterate through our select_values array
+    foreach($select_values as $key => $value) {
+      $query->condition('t.'.$key, $value, '=');
+    }
+    $record = $query->execute()->fetchAll();
+
+    // If it exists and the mode is 1 (Insert Only), then throw an exception.
+    if (sizeof($record) == 1) {
+      if ($mode == $insert_only) {
+        throw new \Exception(
+          t("Record '@record_type' already exists but you chose to only insert (mode=@mode). Values: " .print_r($select_values, TRUE), ['@record_type'=>$record_type, '@mode'=>$mode])
+        );
+        return FALSE;
+      }
+      // Otherwise the mode allows select so return the value of the primary key.
+      else {
+        return $record[0]->{$pkey};
+      }
+    }
+
+    // If more then one result is returned then this is NOT UNIQUE and we should report an
+    // error to the user - not just run with the first one.
+    elseif (sizeof($record) > 1) {
+      throw new \Exception(
+        t("Record '@record_type' is not unique (mode=@mode). Values: " .print_r($select_values, TRUE), ['@record_type'=>$record_type, '@mode'=>$mode])
+      );
+      return FALSE;
+    }
+
+    // If there is no pre-existing record but we've been given permission to create it,
+    // then insert it
+    elseif ($mode != $select_only) {
+
+      // If we want to insert values, we can merge our values to have all the information we need
+      $values = array_merge($select_values, $insert_values);
+
+      // Insert all of our values
+      $result = $this->connection->insert('1:' . $table)
+        ->fields($values)
+        ->execute();
+
+      // If the primary key is available then the insert worked and we can return it.
+      if ($result) {
+        return $result;
+      } 
+      else { // Otherwise, something went wrong so tell the user
+        throw new \Exception(
+          t("Tried to insert '@record_type' but the primary key is returned empty (mode=@mode). Values: " .print_r($select_values, TRUE), ['@record_type'=>$record_type, '@mode'=>$mode])
+        );
+        return FALSE;
+      }
+    }
+    // If there is no pre-existing record and we are not allowed to create one,
+    // then return an error.
+    else {
+      throw new \Exception(
+        t("Record '@record_type' doesn't already exist but you chose to only select (mode=@mode). Values: " .print_r($select_values, TRUE), ['@record_type'=>$record_type, '@mode'=>$mode])
+      );
+      return FALSE;
+    }
+  }
+
   /****************************************************************************
    *  Setter functions
    ****************************************************************************/
@@ -146,12 +234,8 @@ abstract class GenotypesLoaderPluginBase extends PluginBase implements Genotypes
   public function setOrganismID( int $organism_id ) {
     
     // Do validation - throw exception if not valid
-    // Open a db connection and query the provided organism ID
-    $connection = \Drupal::service('tripal_chado.database');
-    $query = $connection->select('1:organism', 'o');
-    $query->fields('o', ['organism_id']);
-    $query->condition('o.organism_id', $organism_id, '=');
-    $result = $query->execute()->fetchField();
+    // Query the provided organism ID
+    $result = $this->getRecordPkey("Organism", "organism", 0, ['organism_id' => $organism_id]);
 
     // Ensure the organism ID exists
     if(!$result) {
@@ -169,12 +253,8 @@ abstract class GenotypesLoaderPluginBase extends PluginBase implements Genotypes
   public function setProjectID( int $project_id ) {
     
     // Do validation - throw exception if not valid
-    // Open a db connection and query the provided project ID
-    $connection = \Drupal::service('tripal_chado.database');
-    $query = $connection->select('1:project', 'p');
-    $query->fields('p', ['project_id']);
-    $query->condition('p.project_id', $project_id, '=');
-    $result = $query->execute()->fetchField();
+    // Query the provided project ID
+    $result = $this->getRecordPkey("Project", "project", 0, ['project_id' => $project_id]);
 
     // Ensure the project ID exists
     if(!$result) {
@@ -192,12 +272,8 @@ abstract class GenotypesLoaderPluginBase extends PluginBase implements Genotypes
   public function setVariantSubTypeID( int $cvterm_id ) {
     
     // Do validation - throw exception if not valid
-    // Open a db connection and query the provided cvterm ID
-    $connection = \Drupal::service('tripal_chado.database');
-    $query = $connection->select('1:cvterm', 'cvt');
-    $query->fields('cvt', ['cvterm_id']);
-    $query->condition('cvt.cvterm_id', $cvterm_id, '=');
-    $result = $query->execute();
+    // Query the provided cvterm ID
+    $result = $this->getRecordPkey("Variant subtype cvterm", "cvterm", 0, ['cvterm_id' => $cvterm_id]);
 
     // Ensure the cvterm ID exists
     if(!$result) {
@@ -215,12 +291,8 @@ abstract class GenotypesLoaderPluginBase extends PluginBase implements Genotypes
   public function setMarkerSubTypeID( int $cvterm_id ) {
     
     // Do validation - throw exception if not valid
-    // Open a db connection and query the provided cvterm ID
-    $connection = \Drupal::service('tripal_chado.database');
-    $query = $connection->select('1:cvterm', 'cvt');
-    $query->fields('cvt', ['cvterm_id']);
-    $query->condition('cvt.cvterm_id', $cvterm_id, '=');
-    $result = $query->execute();
+    // Query the provided cvterm ID
+    $result = $this->getRecordPkey("Marker subtype cvterm", "cvterm", 0, ['cvterm_id' => $cvterm_id]);
 
     // Ensure the cvterm ID exists
     if(!$result) {
@@ -355,100 +427,5 @@ abstract class GenotypesLoaderPluginBase extends PluginBase implements Genotypes
    */ 
   public function getSampleFilepath() {
     return $this->sample_file;
-  }
-
-  /****************************************************************************
-   *  Other functions
-   ****************************************************************************/
-
-   /**
-    * {@inheritdoc}
-    */
-  public function getRecordPkey(string $record_type, string $table, int $mode, array $select_values, array $insert_values = []) {
-    
-    // Check if the mode is one of the 3 options, throw an exception otherwise 
-    $valid_modes = [0, 1, 2];
-
-    if (!in_array($mode, $valid_modes)) {
-      throw new \Exception(
-        t("The specified mode is not valid (mode=@mode)." , ['@mode'=>$mode])
-      );
-      return FALSE;
-    }
-
-    // Set some variables to abstract mode
-    $select_only = 0;
-    $insert_only = 1;
-    $both = 2;
-
-    // the name of the primary key.
-    $pkey = $table . '_id';
-
-    // Open a db connection
-    $connection = \Drupal::service('tripal_chado.database');
-
-    // First we select the record to see if it already exists.
-    $query = $connection->select('1:' . $table, 't');
-    $query->fields('t', [$pkey]);
-    // Iterate through our select_values array
-    foreach($select_values as $key => $value) {
-      $query->condition('t.'.$key, $value, '=');
-    }
-    $record = $query->execute()->fetchAll();
-
-    // If it exists and the mode is 1 (Insert Only), then throw an exception.
-    if (sizeof($record) == 1) {
-      if ($mode == $insert_only) {
-        throw new \Exception(
-          t("Record '@record_type' already exists but you chose to only insert (mode=@mode). Values: " .print_r($select_values, TRUE), ['@record_type'=>$record_type, '@mode'=>$mode])
-        );
-        return FALSE;
-      }
-      // Otherwise the mode allows select so return the value of the primary key.
-      else {
-        return $record[0]->{$pkey};
-      }
-    }
-
-    // If more then one result is returned then this is NOT UNIQUE and we should report an
-    // error to the user - not just run with the first one.
-    elseif (sizeof($record) > 1) {
-      throw new \Exception(
-        t("Record '@record_type' is not unique (mode=@mode). Values: " .print_r($select_values, TRUE), ['@record_type'=>$record_type, '@mode'=>$mode])
-      );
-      return FALSE;
-    }
-
-    // If there is no pre-existing record but we've been given permission to create it,
-    // then insert it
-    elseif ($mode != $select_only) {
-
-      // If we want to insert values, we can merge our values to have all the information we need
-      $values = array_merge($select_values, $insert_values);
-
-      // Insert all of our values
-      $result = $connection->insert('1:' . $table)
-        ->fields($values)
-        ->execute();
-
-      // If the primary key is available then the insert worked and we can return it.
-      if ($result) {
-        return $result;
-      } 
-      else { // Otherwise, something went wrong so tell the user
-        throw new \Exception(
-          t("Tried to insert '@record_type' but the primary key is returned empty (mode=@mode). Values: " .print_r($select_values, TRUE), ['@record_type'=>$record_type, '@mode'=>$mode])
-        );
-        return FALSE;
-      }
-    }
-    // If there is no pre-existing record and we are not allowed to create one,
-    // then return an error.
-    else {
-      throw new \Exception(
-        t("Record '@record_type' doesn't already exist but you chose to only select (mode=@mode). Values: " .print_r($select_values, TRUE), ['@record_type'=>$record_type, '@mode'=>$mode])
-      );
-      return FALSE;
-    }
   }
 }

--- a/trpcultivate_genotypes/src/GenotypesLoader/GenotypesLoaderPluginBase.php
+++ b/trpcultivate_genotypes/src/GenotypesLoader/GenotypesLoaderPluginBase.php
@@ -151,7 +151,7 @@ abstract class GenotypesLoaderPluginBase extends PluginBase implements Genotypes
     $query = $connection->select('1:organism', 'o');
     $query->fields('o', ['organism_id']);
     $query->condition('o.organism_id', $organism_id, '=');
-    $result = $query->execute();
+    $result = $query->execute()->fetchField();
 
     // Ensure the organism ID exists
     if(!$result) {
@@ -174,7 +174,7 @@ abstract class GenotypesLoaderPluginBase extends PluginBase implements Genotypes
     $query = $connection->select('1:project', 'p');
     $query->fields('p', ['project_id']);
     $query->condition('p.project_id', $project_id, '=');
-    $result = $query->execute();
+    $result = $query->execute()->fetchField();
 
     // Ensure the project ID exists
     if(!$result) {
@@ -366,12 +366,20 @@ abstract class GenotypesLoaderPluginBase extends PluginBase implements Genotypes
     */
   public function getRecordPkey(string $record_type, string $table, int $mode, array $select_values, array $insert_values = []) {
     
+    // Check if the mode is one of the 3 options, throw an exception otherwise 
+    $valid_modes = [0, 1, 2];
+
+    if (!in_array($mode, $valid_modes)) {
+      throw new \Exception(
+        t("The specified mode is not valid. (mode=@mode)." , ['@mode'=>$mode])
+      );
+      return FALSE;
+    }
+
     // Set some variables to abstract mode
     $select_only = 0;
     $insert_only = 1;
     $both = 2;
-
-    // @todo: Check if the mode is one of the 3 options, throw an exception otherwise 
 
     // the name of the primary key.
     $pkey = $table . '_id';

--- a/trpcultivate_genotypes/src/GenotypesLoader/GenotypesLoaderPluginManager.php
+++ b/trpcultivate_genotypes/src/GenotypesLoader/GenotypesLoaderPluginManager.php
@@ -91,7 +91,7 @@ class GenotypesLoaderPluginManager extends DefaultPluginManager {
     }
     catch ( \Exception $e ) { 
       throw new \Exception(
-        t("Could not set a parameter while instanciating GenotypesLoader: '@pluginId'" , ['@pluginId'=>$pluginId]) . $e->geMessage()
+        t("Could not set a parameter while instanciating GenotypesLoader: '@pluginId'" , ['@pluginId'=>$pluginId]) . $e->getMessage()
       );
     }
 

--- a/trpcultivate_genotypes/tests/src/Functional/GenotypesLoader/GenotypesLoaderBasePluginTest.php
+++ b/trpcultivate_genotypes/tests/src/Functional/GenotypesLoader/GenotypesLoaderBasePluginTest.php
@@ -71,8 +71,7 @@ class GenotypesLoaderBasePluginTest extends ChadoTestBrowserBase {
     $genus = "Tripalus";
     $species = "databasica";
     $organism_id = $connection->insert('1:organism')
-      ->fields(['genus', 'species'])
-      ->values([
+      ->fields([
         'genus' => $genus,
         'species' => $species,
       ])
@@ -89,8 +88,7 @@ class GenotypesLoaderBasePluginTest extends ChadoTestBrowserBase {
     // Create a project
     $project_name = "Test Project";
     $project_id = $connection->insert('1:project')
-      ->fields(['name'])
-      ->values([
+      ->fields([
         'name' => $project_name,
       ])
       ->execute();
@@ -196,12 +194,11 @@ class GenotypesLoaderBasePluginTest extends ChadoTestBrowserBase {
 
     // Enter a duplicate record to trigger an exception
     $dup_organism_id = $connection->insert('1:organism')
-    ->fields(['genus', 'species'])
-    ->values([
-      'genus' => $genus,
-      'species' => $species,
-    ])
-    ->execute();
+      ->fields([
+        'genus' => $genus,
+        'species' => $species,
+      ])
+      ->execute();
 
     $exception_caught = FALSE;
     try {

--- a/trpcultivate_genotypes/tests/src/Functional/GenotypesLoader/GenotypesLoaderBasePluginTest.php
+++ b/trpcultivate_genotypes/tests/src/Functional/GenotypesLoader/GenotypesLoaderBasePluginTest.php
@@ -161,20 +161,20 @@ class GenotypesLoaderBasePluginTest extends ChadoTestBrowserBase {
     /****************************************************************************
      *  TESTS for method getRecordPkey()
      ****************************************************************************/
-    // Get the primary key of the organism we created using getRecordPkey()
-    $organism_id = $plugin->getRecordPkey('Organism', 'organism', 0, array(
+    // Get the primary key of the organism we previously created using getRecordPkey()
+    $new_organism_id = $plugin->getRecordPkey('Organism', 'organism', 0, [
       'genus' => $genus,
       'species' => $species
-    ));
-    $this->assertEquals($organism_id, $grabbed_organism_id, "The organism Id grabbed by getRecordPkey() does not match.");
+    ]);
+    $this->assertEquals($new_organism_id, $grabbed_organism_id, "The organism ID selected by getRecordPkey() does not match.");
 
     // Try to select a record using an invalid mode
     $exception_caught = FALSE;
     try {
-      $organism_id = $plugin->getRecordPkey('Organism', 'organism', 5, array(
+      $plugin->getRecordPkey('Organism', 'organism', 5, [
         'genus' => $genus,
         'species' => $species
-      ));
+      ]);
     }
     catch ( \Exception $e ) { 
       $exception_caught = TRUE;
@@ -184,10 +184,10 @@ class GenotypesLoaderBasePluginTest extends ChadoTestBrowserBase {
     // Try to insert a record that already exists and catch the expected exception
     $exception_caught = FALSE;
     try {
-      $plugin->getRecordPkey('Organism', 'organism', 1, array(
+      $plugin->getRecordPkey('Organism', 'organism', 1, [
         'genus' => $genus,
         'species' => $species
-      ));
+      ]);
     } 
     catch ( \Exception $e ) { 
       $exception_caught = TRUE;
@@ -195,7 +195,7 @@ class GenotypesLoaderBasePluginTest extends ChadoTestBrowserBase {
     $this->assertTrue($exception_caught, "Did not catch exception for trying to insert a duplicate.");
 
     // Enter a duplicate record to trigger an exception
-    $organism_id = $connection->insert('1:organism')
+    $dup_organism_id = $connection->insert('1:organism')
     ->fields(['genus', 'species'])
     ->values([
       'genus' => $genus,
@@ -205,10 +205,10 @@ class GenotypesLoaderBasePluginTest extends ChadoTestBrowserBase {
 
     $exception_caught = FALSE;
     try {
-      $organism_id = $plugin->getRecordPkey('Organism', 'organism', 2, array(
+      $plugin->getRecordPkey('Organism', 'organism', 2, [
         'genus' => $genus,
         'species' => $species
-      ));
+      ]);
     }
     catch ( \Exception $e ) { 
       $exception_caught = TRUE;
@@ -218,11 +218,11 @@ class GenotypesLoaderBasePluginTest extends ChadoTestBrowserBase {
     // Try to insert an organism with improper values to trigger an exception
     $exception_caught = FALSE;
     try {
-      $organism_id = $plugin->getRecordPkey('Organism', 'organism', 1, array(
+      $plugin->getRecordPkey('Organism', 'organism', 1, [
         'genus' => $genus,
         'species' => $species,
         'blah' => "blah"
-      ));
+      ]);
     }
     catch ( \Exception $e ) { 
       $exception_caught = TRUE;
@@ -232,10 +232,10 @@ class GenotypesLoaderBasePluginTest extends ChadoTestBrowserBase {
     // Test if we can select a record that does not exist, and catch the exception 
     $exception_caught = FALSE;
     try {
-      $new_organism_id = $plugin->getRecordPkey('Organism', 'organism', 0, array(
+      $plugin->getRecordPkey('Organism', 'organism', 0, [
         'genus' => "Felis",
         'species' => "silvestris"
-      ));
+      ]);
     }
     catch ( \Exception $e ) { 
       $exception_caught = TRUE;
@@ -243,14 +243,15 @@ class GenotypesLoaderBasePluginTest extends ChadoTestBrowserBase {
     $this->assertTrue($exception_caught, "Did not catch exception for selecting a non-existing record.");
 
     // Now that we confirmed the new record doesn't exist, try to insert it
-    $new_organism_id = $plugin->getRecordPkey('Organism', 'organism', 1, array('genus' => "Felis"), array('species' => "silvestris"));
+    $felis_organism_id = $plugin->getRecordPkey('Organism', 'organism', 1, ['genus' => "Felis"], ['species' => "silvestris"]);
+    $this->assertIsNumeric($felis_organism_id, "Did not successfully insert a new organism (Felis silvestris) using getRecordPkey()");
 
     // Select it again to confirm that it now exists
-    $select_new_organism_id = $plugin->getRecordPkey('Organism', 'organism', 0, array(
+    $select_felis_organism_id = $plugin->getRecordPkey('Organism', 'organism', 0, [
       'genus' => "Felis",
       'species' => "silvestris"
-    ));
-    $this->assertEquals($new_organism_id, $select_new_organism_id, "Could not select a new record inserted using method getRecordPkey()");
+    ]);
+    $this->assertEquals($felis_organism_id, $select_felis_organism_id, "Could not select a new record inserted using method getRecordPkey()");
 
   }
 }

--- a/trpcultivate_genotypes/tests/src/Functional/GenotypesLoader/GenotypesLoaderBasePluginTest.php
+++ b/trpcultivate_genotypes/tests/src/Functional/GenotypesLoader/GenotypesLoaderBasePluginTest.php
@@ -68,11 +68,13 @@ class GenotypesLoaderBasePluginTest extends ChadoTestBrowserBase {
     $doAssertDependencyInjectionClosure();
 
     // Create an organism
+    $genus = "Tripalus";
+    $species = "databasica";
     $organism_id = $connection->insert('1:organism')
       ->fields(['genus', 'species'])
       ->values([
-        'genus' => 'Tripalus',
-        'species' => 'databasica',
+        'genus' => $genus,
+        'species' => $species,
       ])
       ->execute();
 
@@ -85,10 +87,11 @@ class GenotypesLoaderBasePluginTest extends ChadoTestBrowserBase {
     $this->assertEquals($organism_id, $grabbed_organism_id, "The organism_id using the getter method does not match.");
 
     // Create a project
+    $project_name = "Test Project";
     $project_id = $connection->insert('1:project')
       ->fields(['name'])
       ->values([
-        'name' => 'Test Project',
+        'name' => $project_name,
       ])
       ->execute();
 
@@ -154,5 +157,13 @@ class GenotypesLoaderBasePluginTest extends ChadoTestBrowserBase {
     // Get sample filepath
     $grabbed_sample_file_path = $plugin->getSampleFilepath();
     $this->assertEquals($sample_file_path, $grabbed_sample_file_path, "The sample filepath grabbed by the getter method does not match.");
+
+    // Get the primary key of the organism we created using getRecordPkey()
+    $organism_id = $plugin->getRecordPkey('Organism', 'organism', 0, array(
+      'genus' => $genus,
+      'species' => $species
+    ));
+    $this->assertEquals($organism_id, $grabbed_organism_id, "The organism Id grabbed by getRecordPkey() does not match.");
+
   }
 }

--- a/trpcultivate_genotypes/tests/src/Functional/GenotypesLoader/GenotypesLoaderBasePluginTest.php
+++ b/trpcultivate_genotypes/tests/src/Functional/GenotypesLoader/GenotypesLoaderBasePluginTest.php
@@ -179,12 +179,12 @@ class GenotypesLoaderBasePluginTest extends ChadoTestBrowserBase {
     catch ( \Exception $e ) { 
       $exception_caught = TRUE;
     }
-    $this->assertTrue($exception_caught, "Did not catch exception for using an inavlid mode (5).");
+    $this->assertTrue($exception_caught, "Did not catch exception for using an invalid mode (5).");
 
     // Try to insert a record that already exists and catch the expected exception
     $exception_caught = FALSE;
     try {
-      $organism_id = $plugin->getRecordPkey('Organism', 'organism', 1, array(
+      $plugin->getRecordPkey('Organism', 'organism', 1, array(
         'genus' => $genus,
         'species' => $species
       ));

--- a/trpcultivate_genotypes/tests/src/Functional/GenotypesLoader/GenotypesLoaderPluginManagerTest.php
+++ b/trpcultivate_genotypes/tests/src/Functional/GenotypesLoader/GenotypesLoaderPluginManagerTest.php
@@ -98,13 +98,29 @@ class GenotypesLoaderPluginManagerTest extends ChadoTestBrowserBase {
     $invalid_input_file_type = 'goose';
     $options["input_file_type"] = $invalid_input_file_type;
 
-    $exception_caught = false;
+    $exception_caught = FALSE;
     try {
       $new_plugin = $plugin_manager->setParameters($options);
     }
     catch ( \Exception $e ) {
-      $exception_caught = true;
+      $exception_caught = TRUE;
     }
-    $this->assertTrue($exception_caught);
+    $this->assertTrue($exception_caught, "Did not catch exception for an invalid input file type.");
+
+    // Reset to a valid input file type
+    $options["input_file_type"] = $input_file_type;
+
+    // Test with an invalid organism ID and use a try-catch to ensure an exception is thrown
+    $invalid_organism = -1;
+    $options["organism_id"] = $invalid_organism;
+    $exception_caught = FALSE;
+    try {
+      $new_plugin = $plugin_manager->setParameters($options);
+    }
+    catch ( \Exception $e ) {
+      $exception_caught = TRUE;
+    }
+    $this->assertTrue($exception_caught, "Did not catch exception for using an invalid organism ID.");
+
   }
 }

--- a/trpcultivate_genotypes/tests/src/Functional/GenotypesLoader/GenotypesLoaderPluginManagerTest.php
+++ b/trpcultivate_genotypes/tests/src/Functional/GenotypesLoader/GenotypesLoaderPluginManagerTest.php
@@ -46,8 +46,7 @@ class GenotypesLoaderPluginManagerTest extends ChadoTestBrowserBase {
     // Start adding to the database what we need in order to build our options array
     // Create an organism
     $organism_id = $connection->insert('1:organism')
-      ->fields(['genus', 'species'])
-      ->values([
+      ->fields([
         'genus' => 'Tripalus',
         'species' => 'databasica',
       ])
@@ -55,8 +54,7 @@ class GenotypesLoaderPluginManagerTest extends ChadoTestBrowserBase {
 
     // Create a project
     $project_id = $connection->insert('1:project')
-      ->fields(['name'])
-      ->values([
+      ->fields([
         'name' => 'Test Project',
       ])
       ->execute();


### PR DESCRIPTION
Issue #17 

### Tripal Version: 4

## Description
This PR implements a method for selecting and inserting records within Chado. It does various validation such as ensuring a record exists if selecting, or doesn't exist if only inserting is allowed. Selecting a record if it exists and inserting if it doesn't is also an option. @laceysanderson and I settled on the name **getRecordPkey()** (vs the old name: genotypes_loader_helper_add_record_with_mode) for both brevity and to indicate what the function returns.

## Testing?
Automated tests were developed for the following:
- Select only an existing record
- Using an invalid mode (value of 5 instead of 0, 1, or 2)
- Insert only of an existing record
- Select/Insert of a record that is duplicated in Chado
- Insert only of a record with an invalid field ("blah" for organism)
- Select only of a non-existing record
- Insert only of a non-existing record

Additionally, I added a test for the plugin manager:
- Provide an invalid organism ID

I am open to suggestions if you think of a case that hasn't been tested :)

Manual testing of the current functionality cannot be done at this time. However, you can clone this repository, access the docker image for this module and tweak the automated tests in the `tests/src/Functional/GenotypesLoader/Subclass` folder and the example input files located in `tests/src/Fixtures`. 

```
docker build --tag=trpcultivate:latest .
docker run --publish=80:80 --name=trpcultivate -tid --volume=`pwd`:/var/www/drupal9/web/modules/contrib/TripalCultivate-Genetics trpcultivate:latest
docker exec trpcultivate service postgresql restart
```
Checkout this branch, then run the tests using `docker exec trpcultivate phpunit --group "Genotypes Loader"`