### PR TITLE
Modified Dockerfile to use noChado docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
-FROM tripalproject/tripaldocker:latest
+ARG drupalversion='10.0.x-dev'
+FROM tripalproject/tripaldocker:drupal${drupalversion}-php8.1-pgsql13-noChado
 
+ARG chadoschema='testchado'
 COPY . /var/www/drupal9/web/modules/contrib/TripalCultivate-Genetics
 
 WORKDIR /var/www/drupal9/web/modules/contrib/TripalCultivate-Genetics
 
 RUN service postgresql restart \
+  && drush trp-install-chado --schema-name=${chadoschema} \
+  && drush trp-prep-chado --schema-name=${chadoschema} \
   && drush en trpcultivate_genetics trpcultivate_genotypes trpcultivate_genomatrix trpcultivate_qtl trpcultivate_vcf --yes


### PR DESCRIPTION
This PR is essentially the same as the following: https://github.com/TripalCultivate/TripalCultivate-Phenotypes/pull/33 which was written and implemented by @laceysanderson. I have copied the necessary code and PR text to get this fix in TripalCultivate-Genetics.

## Motivation
While the docker was able to build with no error, however, when I load the homepage it is a WSOD with the following error message:
```
Drupal\tripal\TripalDBX\Exceptions\SchemaException: Invalid or unsupported Chado schema version ''. in Drupal\tripal_chado\Database\ChadoSchema->getSchemaDef() (line 56 of modules/contrib/tripal/tripal_chado/src/Database/ChadoSchema.php).
```

The motivation for this PR is to fix that issue so we can actually use our docker site again ;-p 

## What does this PR do?
1. Switches the dockerfile to use `-noChado` images from Tripal core added via https://github.com/tripal/tripal/pull/1575
2. Updates the dockerfile to both install and prepare chado based on the supplied arguement with a default of `testchado`.

## Testing
1. Build the docker image
2. Ensure you can load the home page of the site by going to https://localhost