### PR TITLE
Added lines to the Dockerfile to import content types

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,7 @@ RUN service postgresql restart \
   && drush trp-prep-chado --schema-name=${chadoschema} \
   && drush tripal:trp-import-types --username=drupaladmin --collection_id=general_chado \
   && drush tripal:trp-import-types --username=drupaladmin --collection_id=germplasm_chado \
+  && drush tripal:trp-import-types --username=drupaladmin --collection_id=genomic_chado \
+  && drush tripal:trp-import-types --username=drupaladmin --collection_id=genetic_chado \
   && drush en trpcultivate_genetics trpcultivate_genotypes trpcultivate_genomatrix trpcultivate_qtl trpcultivate_vcf --yes \
   && drush cr

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,7 @@ WORKDIR /var/www/drupal/web/modules/contrib/TripalCultivate-Genetics
 RUN service postgresql restart \
   && drush trp-install-chado --schema-name=${chadoschema} \
   && drush trp-prep-chado --schema-name=${chadoschema} \
-  && drush en trpcultivate_genetics trpcultivate_genotypes trpcultivate_genomatrix trpcultivate_qtl trpcultivate_vcf --yes
+  && drush tripal:trp-import-types --username=drupaladmin --collection_id=general_chado \
+  && drush tripal:trp-import-types --username=drupaladmin --collection_id=germplasm_chado \
+  && drush en trpcultivate_genetics trpcultivate_genotypes trpcultivate_genomatrix trpcultivate_qtl trpcultivate_vcf --yes \
+  && drush cr


### PR DESCRIPTION
**Issue #32**

## Motivation

<!-- This can usually be copied from the issue. Please do not just say, go see issue but instead copy the relevant details here. --> 
This PR is introducing the same fix to the dockerfile for importing content types as https://github.com/TripalCultivate/TripalCultivate-Phenotypes/pull/56 did. This fix is needed since Tripal Core PR https://github.com/tripal/tripal/pull/1696 was merged, and it changed the purpose of prepare and how content types were created. Note that the change in the phenotypes PR involving running trp-run-jobs was unnecessary for this module and thus has been left out of this PR.

## What does this PR do?

1. Adds drush commands to the dockerfile to import the General + Germplasm content type collections in core.
2. Adds a cache rebuild command (`drush cr`) to the end of the Dockerfile since I know this will help in the future once a form for the Genotypes Loader is developed. Often, a cache rebuild is needed after install to have the form appear in the listing.

## Testing

### Manual Testing
See https://github.com/TripalCultivate/TripalCultivate-Phenotypes/pull/56 for step-by-step instructions including screenshots.

Here are the specific commands I used for setting up my docker environment:
```
git clone https://github.com/TripalCultivate/TripalCultivate-Genetics.git trpcultivate-g0.32
cd trpcultivate-g0.32
git checkout g0.32-importContentTypes
docker build --tag=trpcultivate:G0.32 ./
docker run --publish=8080:80 --name=trpcultivate-G0.32 -tid --volume=`pwd`:/var/www/drupal/web/modules/contrib/TripalCultivate-Genetics trpcultivate:G0.32
docker exec trpcultivate-G0.32 service postgresql restart
```

Then I logged into the site and navigated to Admin > Tripal > Page Structure and confirmed that the expected content types were there.

I was also successfully able to create an organism through Admin > Tripal > Content > Add Tripal Content