### PR TITLE
Update dependencies and use new theme/base

### DIFF
--- a/.github/workflows/ALL-PHPUnit.yml
+++ b/.github/workflows/ALL-PHPUnit.yml
@@ -16,12 +16,27 @@ jobs:
         php-version:
           - "8.1"
           - "8.2"
+          - "8.3"
         pgsql-version:
           - "13"
+          - "16"
         drupal-version:
           - "10.0.x-dev"
           - "10.1.x-dev"
-
+          - "10.2.x-dev"
+        excludes:
+          - php-version: "8.3"
+            pgsql-version: "13"
+            drupal-version: "10.0.x-dev"
+          - php-version: "8.3"
+            pgsql-version: "13"
+            drupal-version: "10.1.x-dev"
+          - php-version: "8.3"
+            pgsql-version: "16"
+            drupal-version: "10.0.x-dev"
+          - php-version: "8.3"
+            pgsql-version: "16"
+            drupal-version: "10.1.x-dev"
     steps:
       # Check out the repo
       - name: Checkout Repository

--- a/.github/workflows/ALL-PHPUnit.yml
+++ b/.github/workflows/ALL-PHPUnit.yml
@@ -40,10 +40,10 @@ jobs:
     steps:
       # Check out the repo
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # Here we pull the development tripaldocker image for this combo in our matrix
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.2
+        uses: tripal/test-tripal-action@v1.5
         with:
           directory-name: $PKG_NAME
           modules: $MODULES

--- a/.github/workflows/ALL-PHPUnit.yml
+++ b/.github/workflows/ALL-PHPUnit.yml
@@ -1,6 +1,17 @@
 
-name: PHPUnit
-on: [push]
+name: PHPUnit Matrixed
+on:
+  push:
+    branches-ignore:
+      - 4.x
+  # Allows us to manually trigger this workflow.
+  # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
+  workflow_dispatch:
+  # Allows us to schedule when this workflow is run.
+  # This ensures we pick up any new changes committed to Tripal Core.
+  schedule:
+    # Run at 2am every night.
+    - cron: '0 2 * * *'
 
 env:
   PKG_NAME: TripalCultivate-Genetics
@@ -19,23 +30,16 @@ jobs:
           - "8.3"
         pgsql-version:
           - "13"
-          - "16"
         drupal-version:
           - "10.0.x-dev"
           - "10.1.x-dev"
           - "10.2.x-dev"
-        excludes:
+        exclude:
           - php-version: "8.3"
             pgsql-version: "13"
             drupal-version: "10.0.x-dev"
           - php-version: "8.3"
             pgsql-version: "13"
-            drupal-version: "10.1.x-dev"
-          - php-version: "8.3"
-            pgsql-version: "16"
-            drupal-version: "10.0.x-dev"
-          - php-version: "8.3"
-            pgsql-version: "16"
             drupal-version: "10.1.x-dev"
     steps:
       # Check out the repo

--- a/.github/workflows/ALL-testCoverage-codeclimate.yml
+++ b/.github/workflows/ALL-testCoverage-codeclimate.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       # Check out the repo
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # Here we pull the development tripaldocker image for this combo in our matrix
       - name: Pull TripalDocker Image
         run: |
@@ -38,7 +38,7 @@ jobs:
           docker exec tripaldocker drush en $MODULES --yes
       # Ensure we have the variables we need.
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v3.x
+        uses: rlespinasse/github-slug-action@v4
       # Prepare for code coverage.
       - name: Prepare for Code Coverage
         run: |

--- a/.github/workflows/ALL-testCoverage-codeclimate.yml
+++ b/.github/workflows/ALL-testCoverage-codeclimate.yml
@@ -5,7 +5,7 @@ on: [push]
 env:
   PKG_NAME: TripalCultivate-Genetics
   MODULES: "trpcultivate_genetics trpcultivate_genotypes trpcultivate_genomatrix trpcultivate_qtl trpcultivate_vcf"
-  IMAGE_TAG: knowpulse/tripalcultivate:baseonly-drupal10.1.x-dev-php8.2-pgsql16
+  IMAGE_TAG: knowpulse/tripalcultivate:baseonly-drupal10.1.x-dev-php8.2-pgsql13
   SIMPLETEST_BASE_URL: "http://localhost"
   SIMPLETEST_DB: "pgsql://drupaladmin:drupaldevelopmentonlylocal@localhost/sitedb"
   BROWSER_OUTPUT_DIRECTORY: "/var/www/drupal/web/sites/default/files/simpletest"
@@ -24,7 +24,7 @@ jobs:
       # Here we pull the development tripaldocker image for this combo in our matrix
       - name: Build TripalDocker Image
         run: |
-          docker build --tag=$IMAGE_TAG --build-arg drupalversion=drupal10.1.x-dev --build-arg phpversion=8.2 ./
+          docker build --tag=$IMAGE_TAG --build-arg drupalversion=drupal10.1.x-dev --build-arg phpversion=8.2 --build-arg pgsqlversion=13 ./
       # Just spin up docker the good ol' fashion way
       # mounting our currently checked out package inside the docker container.
       - name: Spin up Docker locally

--- a/.github/workflows/ALL-testCoverage-codeclimate.yml
+++ b/.github/workflows/ALL-testCoverage-codeclimate.yml
@@ -22,9 +22,9 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
       # Here we pull the development tripaldocker image for this combo in our matrix
-      - name: Pull TripalDocker Image
+      - name: Build TripalDocker Image
         run: |
-          build --tag=$IMAGE_TAG --build-arg drupalversion=${{ matrix.drupal-version }} --build-arg phpversion=${{ matrix.php-version }} ./
+          docker build --tag=$IMAGE_TAG --build-arg drupalversion=drupal10.1.x-dev --build-arg phpversion=8.2 ./
       # Just spin up docker the good ol' fashion way
       # mounting our currently checked out package inside the docker container.
       - name: Spin up Docker locally

--- a/.github/workflows/ALL-testCoverage-codeclimate.yml
+++ b/.github/workflows/ALL-testCoverage-codeclimate.yml
@@ -5,7 +5,7 @@ on: [push]
 env:
   PKG_NAME: TripalCultivate-Genetics
   MODULES: "trpcultivate_genetics trpcultivate_genotypes trpcultivate_genomatrix trpcultivate_qtl trpcultivate_vcf"
-  IMAGE_TAG: knowpulse/tripalcultivate:baseonly-drupal10.1.x-dev-php8.2-pgsql13
+  IMAGE_TAG: tripalcultivate:localdocker
   SIMPLETEST_BASE_URL: "http://localhost"
   SIMPLETEST_DB: "pgsql://drupaladmin:drupaldevelopmentonlylocal@localhost/sitedb"
   BROWSER_OUTPUT_DIRECTORY: "/var/www/drupal/web/sites/default/files/simpletest"
@@ -24,7 +24,7 @@ jobs:
       # Here we pull the development tripaldocker image for this combo in our matrix
       - name: Build TripalDocker Image
         run: |
-          docker build --tag=$IMAGE_TAG --build-arg drupalversion=drupal10.1.x-dev --build-arg phpversion=8.2 --build-arg pgsqlversion=13 ./
+          docker build --tag=$IMAGE_TAG --build-arg drupalversion=10.1.x-dev --build-arg phpversion=8.2 --build-arg pgsqlversion=13 ./
       # Just spin up docker the good ol' fashion way
       # mounting our currently checked out package inside the docker container.
       - name: Spin up Docker locally

--- a/.github/workflows/ALL-testCoverage-codeclimate.yml
+++ b/.github/workflows/ALL-testCoverage-codeclimate.yml
@@ -5,7 +5,7 @@ on: [push]
 env:
   PKG_NAME: TripalCultivate-Genetics
   MODULES: "trpcultivate_genetics trpcultivate_genotypes trpcultivate_genomatrix trpcultivate_qtl trpcultivate_vcf"
-  IMAGE_TAG: drupal10.1.x-dev-php8.2-pgsql13
+  IMAGE_TAG: knowpulse/tripalcultivate:baseonly-drupal10.1.x-dev-php8.2-pgsql16
   SIMPLETEST_BASE_URL: "http://localhost"
   SIMPLETEST_DB: "pgsql://drupaladmin:drupaldevelopmentonlylocal@localhost/sitedb"
   BROWSER_OUTPUT_DIRECTORY: "/var/www/drupal/web/sites/default/files/simpletest"
@@ -24,13 +24,13 @@ jobs:
       # Here we pull the development tripaldocker image for this combo in our matrix
       - name: Pull TripalDocker Image
         run: |
-          docker pull tripalproject/tripaldocker:$IMAGE_TAG
+          build --tag=$IMAGE_TAG --build-arg drupalversion=${{ matrix.drupal-version }} --build-arg phpversion=${{ matrix.php-version }} ./
       # Just spin up docker the good ol' fashion way
       # mounting our currently checked out package inside the docker container.
       - name: Spin up Docker locally
         run: |
           docker run --publish=80:80 --name=tripaldocker -tid \
-            --volume=`pwd`:/var/www/drupal/web/modules/contrib/$PKG_NAME tripalproject/tripaldocker:$IMAGE_TAG
+            --volume=`pwd`:/var/www/drupal/web/modules/contrib/$PKG_NAME $IMAGE_TAG
       # Install the modules
       - name: Install our package in Docker
         run: |

--- a/.github/workflows/MAIN-phpunit-Grid1A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1A.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - 4.x
-      - g5.18-updateTestingGrid
 jobs:
   run-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/MAIN-phpunit-Grid1A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1A.yml
@@ -18,5 +18,5 @@ jobs:
           build-image: TRUE
           dockerfile: 'Dockerfile'
           php-version: '8.1'
-          pgsql-version: '13'
+          pgsql-version: '16'
           drupal-version: '10.0.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid1A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1A.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.2
+        uses: tripal/test-tripal-action@v1.5
         with:
           directory-name: 'TripalCultivate-Genetics'
           modules: 'trpcultivate_genetics trpcultivate_genotypes trpcultivate_genomatrix trpcultivate_qtl trpcultivate_vcf'

--- a/.github/workflows/MAIN-phpunit-Grid1B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1B.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - 4.x
-      - g5.18-updateTestingGrid
 jobs:
   run-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/MAIN-phpunit-Grid1B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1B.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.2
+        uses: tripal/test-tripal-action@v1.5
         with:
           directory-name: 'TripalCultivate-Genetics'
           modules: 'trpcultivate_genetics trpcultivate_genotypes trpcultivate_genomatrix trpcultivate_qtl trpcultivate_vcf'

--- a/.github/workflows/MAIN-phpunit-Grid1C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1C.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - 4.x
-      - g5.18-updateTestingGrid
 jobs:
   run-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/MAIN-phpunit-Grid1C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1C.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.2
+        uses: tripal/test-tripal-action@v1.5
         with:
           directory-name: 'TripalCultivate-Genetics'
           modules: 'trpcultivate_genetics trpcultivate_genotypes trpcultivate_genomatrix trpcultivate_qtl trpcultivate_vcf'

--- a/.github/workflows/MAIN-phpunit-Grid1C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1C.yml
@@ -19,4 +19,4 @@ jobs:
           dockerfile: 'Dockerfile'
           php-version: '8.1'
           pgsql-version: '16'
-          drupal-version: '10.1.x-dev'
+          drupal-version: '10.2.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid2A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2A.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.2
+        uses: tripal/test-tripal-action@v1.5
         with:
           directory-name: 'TripalCultivate-Genetics'
           modules: 'trpcultivate_genetics trpcultivate_genotypes trpcultivate_genomatrix trpcultivate_qtl trpcultivate_vcf'

--- a/.github/workflows/MAIN-phpunit-Grid2A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2A.yml
@@ -17,6 +17,6 @@ jobs:
           modules: 'trpcultivate_genetics trpcultivate_genotypes trpcultivate_genomatrix trpcultivate_qtl trpcultivate_vcf'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: '8.1'
-          pgsql-version: '13'
-          drupal-version: '10.1.x-dev'
+          php-version: '8.2'
+          pgsql-version: '16'
+          drupal-version: '10.0.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid2A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2A.yml
@@ -3,13 +3,12 @@ on:
   push:
     branches:
       - 4.x
-      - g5.18-updateTestingGrid
 jobs:
   run-tests:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
       - name: Run Automated testing
         uses: tripal/test-tripal-action@v1.5
         with:

--- a/.github/workflows/MAIN-phpunit-Grid2B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2B.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - 4.x
-      - g5.18-updateTestingGrid
 jobs:
   run-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/MAIN-phpunit-Grid2B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2B.yml
@@ -18,5 +18,5 @@ jobs:
           build-image: TRUE
           dockerfile: 'Dockerfile'
           php-version: '8.2'
-          pgsql-version: '13'
+          pgsql-version: '16'
           drupal-version: '10.1.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid2B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2B.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.2
+        uses: tripal/test-tripal-action@v1.5
         with:
           directory-name: 'TripalCultivate-Genetics'
           modules: 'trpcultivate_genetics trpcultivate_genotypes trpcultivate_genomatrix trpcultivate_qtl trpcultivate_vcf'

--- a/.github/workflows/MAIN-phpunit-Grid2C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2C.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - 4.x
-      - g5.18-updateTestingGrid
 jobs:
   run-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/MAIN-phpunit-Grid2C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2C.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.2
+        uses: tripal/test-tripal-action@v1.5
         with:
           directory-name: 'TripalCultivate-Genetics'
           modules: 'trpcultivate_genetics trpcultivate_genotypes trpcultivate_genomatrix trpcultivate_qtl trpcultivate_vcf'

--- a/.github/workflows/MAIN-phpunit-Grid2C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2C.yml
@@ -17,6 +17,6 @@ jobs:
           modules: 'trpcultivate_genetics trpcultivate_genotypes trpcultivate_genomatrix trpcultivate_qtl trpcultivate_vcf'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: '8.1'
+          php-version: '8.2'
           pgsql-version: '16'
-          drupal-version: '10.1.x-dev'
+          drupal-version: '10.2.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid3C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3C.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - 4.x
-      - g5.18-updateTestingGrid
 jobs:
   run-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/MAIN-phpunit-Grid3C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3C.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.2
+        uses: tripal/test-tripal-action@v1.5
         with:
           directory-name: 'TripalCultivate-Genetics'
           modules: 'trpcultivate_genetics trpcultivate_genotypes trpcultivate_genomatrix trpcultivate_qtl trpcultivate_vcf'

--- a/.github/workflows/MAIN-phpunit-Grid3C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3C.yml
@@ -17,6 +17,6 @@ jobs:
           modules: 'trpcultivate_genetics trpcultivate_genotypes trpcultivate_genomatrix trpcultivate_qtl trpcultivate_vcf'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: '8.1'
+          php-version: '8.3'
           pgsql-version: '16'
-          drupal-version: '10.1.x-dev'
+          drupal-version: '10.2.x-dev'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG drupalversion='10.0.x-dev'
+ARG drupalversion='10.2.x-dev'
 ARG phpversion='8.3'
 ARG pgsqlversion='16'
 FROM knowpulse/tripalcultivate:baseonly-drupal${drupalversion}-php${phpversion}-pgsql${pgsqlversion}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,11 @@
 ARG drupalversion='10.0.x-dev'
-FROM tripalproject/tripaldocker:drupal${drupalversion}-php8.1-pgsql13-noChado
+ARG phpversion='8.3'
+ARG pgsqlversion='16'
+FROM knowpulse/tripalcultivate:baseonly-drupal${drupalversion}-php${phpversion}-pgsql${pgsqlversion}
 
-ARG chadoschema='testchado'
 COPY . /var/www/drupal/web/modules/contrib/TripalCultivate-Genetics
-
 WORKDIR /var/www/drupal/web/modules/contrib/TripalCultivate-Genetics
 
 RUN service postgresql restart \
-  && drush trp-install-chado --schema-name=${chadoschema} \
-  && drush trp-prep-chado --schema-name=${chadoschema} \
-  && drush tripal:trp-import-types --username=drupaladmin --collection_id=general_chado \
-  && drush tripal:trp-import-types --username=drupaladmin --collection_id=germplasm_chado \
-  && drush tripal:trp-import-types --username=drupaladmin --collection_id=genomic_chado \
-  && drush tripal:trp-import-types --username=drupaladmin --collection_id=genetic_chado \
   && drush en trpcultivate_genetics trpcultivate_genotypes trpcultivate_genomatrix trpcultivate_qtl trpcultivate_vcf --yes \
   && drush cr

--- a/README.md
+++ b/README.md
@@ -59,10 +59,11 @@ maintainability issues and test coverage.
 
 The following compatibility is proven via automated testing workflows.
 
-| Drupal      | 10.0.x          | 10.1.x          |
-|-------------|-----------------|-----------------|
-| **PHP 8.1** | ![Grid1A-Badge] | ![Grid1B-Badge] |
-| **PHP 8.2** | ![Grid2A-Badge] | ![Grid2B-Badge] |
+|  Drupal     |  10.0.x         |  10.1.x         |  10.2.x         |
+|-------------|-----------------|-----------------|-----------------|
+| **PHP 8.1** | ![Grid1A-Badge] | ![Grid1B-Badge] | ![Grid1C-Badge] |
+| **PHP 8.2** | ![Grid2A-Badge] | ![Grid2B-Badge] | ![Grid2C-Badge] |
+| **PHP 8.3** |                 |                 | ![Grid3C-Badge] |
 
 [our CodeClimate project page]: https://codeclimate.com/github/TripalCultivate/TripalCultivate-Genetics
 [MaintainabilityBadge]: https://api.codeclimate.com/v1/badges/fddbd06df5e320f09cd9/maintainability
@@ -70,6 +71,10 @@ The following compatibility is proven via automated testing workflows.
 
 [Grid1A-Badge]: https://github.com/TripalCultivate/TripalCultivate-Genetics/actions/workflows/MAIN-phpunit-Grid1A.yml/badge.svg
 [Grid1B-Badge]: https://github.com/TripalCultivate/TripalCultivate-Genetics/actions/workflows/MAIN-phpunit-Grid1B.yml/badge.svg
+[Grid1C-Badge]: https://github.com/TripalCultivate/TripalCultivate-Genetics/actions/workflows/MAIN-phpunit-Grid1C.yml/badge.svg
 
 [Grid2A-Badge]: https://github.com/TripalCultivate/TripalCultivate-Genetics/actions/workflows/MAIN-phpunit-Grid2A.yml/badge.svg
 [Grid2B-Badge]: https://github.com/TripalCultivate/TripalCultivate-Genetics/actions/workflows/MAIN-phpunit-Grid2B.yml/badge.svg
+[Grid2C-Badge]: https://github.com/TripalCultivate/TripalCultivate-Genetics/actions/workflows/MAIN-phpunit-Grid2C.yml/badge.svg
+
+[Grid3C-Badge]: https://github.com/TripalCultivate/TripalCultivate-Genetics/actions/workflows/MAIN-phpunit-Grid3C.yml/badge.svg

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,9 @@
         }
   ],
   "require": {
-    "php": "^8.0",
-    "drupal/core": "^9.4",
-    "tripal/tripal": "^4.0-alpha1"
+    "php": "^8.1",
+    "drupal/core": "^10.0",
+    "tripal/tripal": "^4.0-alpha1",
+    "tripalcultivate/base": "*"
   }
 }

--- a/trpcultivate_genetics/trpcultivate_genetics.info.yml
+++ b/trpcultivate_genetics/trpcultivate_genetics.info.yml
@@ -2,7 +2,8 @@ name: Genetic Data API
 type: module
 description: Provides generic support for large-scale genotypic data, genetic maps, and QTL with importers, content pages and visualizations.
 package: "TripalCultivate: Genetics"
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10
 dependencies:
   - tripal
   - tripal_chado
+  - trpcultivate

--- a/trpcultivate_genomatrix/trpcultivate_genomatrix.info.yml
+++ b/trpcultivate_genomatrix/trpcultivate_genomatrix.info.yml
@@ -2,7 +2,7 @@ name: Genotype Matrix
 type: module
 description: Creates a germplasm by marker matrix tool for quick visual querying of genotypic differences in smaller regions (e.g. QTL or GWAS peak).
 package: "TripalCultivate: Genetics"
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10
 dependencies:
   - tripal
   - tripal_chado

--- a/trpcultivate_genotypes/trpcultivate_genotypes.info.yml
+++ b/trpcultivate_genotypes/trpcultivate_genotypes.info.yml
@@ -2,7 +2,7 @@ name: Genotypic Data
 type: module
 description: Expands Chado to support large-scale genotypic data.
 package: "TripalCultivate: Genetics"
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10
 dependencies:
   - tripal
   - tripal_chado

--- a/trpcultivate_qtl/trpcultivate_qtl.info.yml
+++ b/trpcultivate_qtl/trpcultivate_qtl.info.yml
@@ -2,7 +2,7 @@ name: Genetic Maps + QTL
 type: module
 description: Expands Tripal Content pages to better support Genetic Maps + QTL.
 package: "TripalCultivate: Genetics"
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10
 dependencies:
   - tripal
   - tripal_chado

--- a/trpcultivate_vcf/trpcultivate_vcf.info.yml
+++ b/trpcultivate_vcf/trpcultivate_vcf.info.yml
@@ -2,7 +2,7 @@ name: Variant Call Format (VCF)
 type: module
 description: Creates a tool for easily filtering VCF files and converting to different formats.
 package: "TripalCultivate: Genetics"
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10
 dependencies:
   - tripal
   - tripal_chado


### PR DESCRIPTION
**Issue #35**

## Motivation

Based on the changes made in https://github.com/TripalCultivate/TripalCultivate/pull/8 we need to update all the packages.

## What does this PR do?
*Please describe each things this PR does. For example, a PR may 1) solve a specific bug, 2) create an automated test to ensure it doesn't return.*

1. Updates dependencies (i.e. Drupal version, Tripal Cultivate Base)
2. Dockerfile now uses TripalCultivate base image instead of Tripal core
3. Update all github action versions to remove warning about Node 20
4. Update automated testing grid to include Drupal 10.2 and PHP 8.2
5. Update all workflows to allow them to be manually triggered and to ensure they are run each night on the most recent changes in dependencies.

NOTE: This module is not yet compatible with Drupal 10.2 so the failing tests for that version of Drupal are expected. This will be fixed in Issue https://github.com/TripalCultivate/TripalCultivate-Genetics/issues/37

## Testing

### Automated Testing
No additional automated testing needed for these changes.

### Manual Testing
*Describe in detail how someone should manually test this functionality.*
*Make sure to include whether they need to build a docker from scratch, create any records, etc.*

1. Check that the automated testing passes. This confirms changes to dependencies, workflows and the Dockerfile did not cause any issues.
2. Build a docker image locally and run a container just to take a look at things.
    - everything is installed and chado is in a schema named `testschema`
    - the content types you expect are available (note: additionally the genetic and genomic will now be available).
    - confirm that the site is now themed green as expected for Tripal Cultivate.