### PR TITLE
G0.49 Add Support for Drupal 11.4

### DIFF
--- a/.github/workflows/ALL-PHPUnit.yml
+++ b/.github/workflows/ALL-PHPUnit.yml
@@ -29,31 +29,26 @@ jobs:
           - "14"
           - "18"
         drupal-version:
-          - "10.5.x"
           - "10.6.x"
-          - "11.2.x"
           - "11.3.x"
+          - "11.4.x"
         exclude:
           # Only Drupal 11.3+ supports PHP 8.5.
           - php-version: "8.5"
-            drupal-version: "10.5.x"
-          - php-version: "8.5"
             drupal-version: "10.6.x"
-          - php-version: "8.5"
-            drupal-version: "11.2.x"
           # Drupal 11+ requires at least Postgresql 16.
           - pgsql-version: "14"
-            drupal-version: "11.2.x"
-          - pgsql-version: "14"
             drupal-version: "11.3.x"
+          - pgsql-version: "14"
+            drupal-version: "11.4.x"
           # Exclude higher postgresql version from middle Drupal versions
           - pgsql-version: "18"
             drupal-version: "10.6.x"
           # Drupal 11+ requires at least php 8.3.
           - php-version: "8.2"
-            drupal-version: "11.2.x"
-          - php-version: "8.2"
             drupal-version: "11.3.x"
+          - php-version: "8.2"
+            drupal-version: "11.4.x"
 
     steps:
       # Check out the repo

--- a/.github/workflows/ALL-testCoverage-codeclimate.yml
+++ b/.github/workflows/ALL-testCoverage-codeclimate.yml
@@ -7,7 +7,7 @@ on: [push, workflow_dispatch]
 
 jobs:
   run-coverage:
-    name: "Drupal 11.3.x - PHP 8.5 - PostgreSQL 18"
+    name: "Drupal 11.4.x - PHP 8.5 - PostgreSQL 18"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -21,5 +21,5 @@ jobs:
           dockerfile: 'Dockerfile'
           php-version: 8.5
           pgsql-version: 18
-          drupal-version: 11.3.x
+          drupal-version: 11.4.x
           qltycloud-reporter-id: ${{ secrets.QLTY_COVERAGE_TOKEN }}

--- a/.github/workflows/MAIN-buildDocker.yml
+++ b/.github/workflows/MAIN-buildDocker.yml
@@ -31,39 +31,34 @@ jobs:
           - "17"
           - "18"
         drupal-version:
-          - "10.5.x"
           - "10.6.x"
-          - "11.x-dev"
-          - "11.2.x"
           - "11.3.x"
+          - "11.4.x"
+          - "11.x-dev"
         exclude:
           # Only Drupal 11.3+ supports PHP 8.5.
           - php-version: "8.5"
-            drupal-version: "10.5.x"
-          - php-version: "8.5"
             drupal-version: "10.6.x"
-          - php-version: "8.5"
-            drupal-version: "11.2.x"
           # Drupal 11.x requires PHP 8.3+.
           - php-version: "8.2"
-            drupal-version: "11.x-dev"
-          - php-version: "8.2"
-            drupal-version: "11.2.x"
-          - php-version: "8.2"
             drupal-version: "11.3.x"
+          - php-version: "8.2"
+            drupal-version: "11.4.x"
+          - php-version: "8.2"
+            drupal-version: "11.x-dev"
           # Drupal 11+ requires at least Postgresql 16.
           - pgsql-version: "14"
-            drupal-version: "11.x-dev"
-          - pgsql-version: "15"
-            drupal-version: "11.x-dev"
-          - pgsql-version: "14"
-            drupal-version: "11.2.x"
-          - pgsql-version: "15"
-            drupal-version: "11.2.x"
-          - pgsql-version: "14"
             drupal-version: "11.3.x"
           - pgsql-version: "15"
             drupal-version: "11.3.x"
+          - pgsql-version: "14"
+            drupal-version: "11.4.x"
+          - pgsql-version: "15"
+            drupal-version: "11.4.x"
+          - pgsql-version: "14"
+            drupal-version: "11.x-dev"
+          - pgsql-version: "15"
+            drupal-version: "11.x-dev"
     name: TripalCultivate ${{ matrix.drupal-version }}-php${{ matrix.php-version }}-pgsql${{ matrix.pgsql-version }}
     steps:
       - uses: actions/checkout@v6
@@ -79,8 +74,8 @@ jobs:
           buildArgs: "drupalversion=${{ matrix.drupal-version }},phpversion=${{ matrix.php-version }},postgresqlversion=${{ matrix.pgsql-version }}"
           labels: 'drupal.version.label="${{ matrix.drupal-version }}",php.version.label="${{ matrix.php-version }}", postgresql.version.label="${{ matrix.pgsql-version }}"'
       - uses: mr-smithers-excellent/docker-build-push@v6.5
-        name: Build latest using 11.3.x, PHP 8.5, PgSQL 18
-        if: ${{ matrix.drupal-version == '11.3.x' && matrix.php-version == '8.5' && matrix.pgsql-version == '18' }}
+        name: Build latest using 11.4.x, PHP 8.5, PgSQL 18
+        if: ${{ matrix.drupal-version == '11.4.x' && matrix.php-version == '8.5' && matrix.pgsql-version == '18' }}
         with:
           image: knowpulse/tripalcultivate-genetics
           tags: latest

--- a/.github/workflows/MAIN-phpunit-php8.3_D11_4x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.3_D11_4x.yml
@@ -14,7 +14,7 @@ permissions: read-all
 
 jobs:
   running-tests:
-    name: 'PHP 8.3 - Drupal 10.5.x - PostgreSQL 18'
+    name: 'PHP 8.3 - Drupal 11.4.x - PostgreSQL 18'
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout Repository'
@@ -25,7 +25,7 @@ jobs:
           directory-name: 'trpcultivate_genetics'
           modules: 'trpcultivate_genetics, trpcultivate_genomatrix, trpcultivate_genotypes, trpcultivate_qtl, trpcultivate_vcf'
           php-version: '8.3'
-          drupal-version: '10.5.x'
+          drupal-version: '11.4.x'
           pgsql-version: '18'
           build-image: TRUE
           dockerfile: 'Dockerfile'

--- a/.github/workflows/MAIN-phpunit-php8.4_D10_6x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.4_D10_6x.yml
@@ -14,7 +14,7 @@ permissions: read-all
 
 jobs:
   running-tests:
-    name: 'PHP 8.3 - Drupal 11.2.x - PostgreSQL 18'
+    name: 'PHP 8.4 - Drupal 10.6.x - PostgreSQL 18'
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout Repository'
@@ -24,8 +24,8 @@ jobs:
         with:
           directory-name: 'trpcultivate_genetics'
           modules: 'trpcultivate_genetics, trpcultivate_genomatrix, trpcultivate_genotypes, trpcultivate_qtl, trpcultivate_vcf'
-          php-version: '8.3'
-          drupal-version: '11.2.x'
+          php-version: '8.4'
+          drupal-version: '10.6.x'
           pgsql-version: '18'
           build-image: TRUE
           dockerfile: 'Dockerfile'

--- a/.github/workflows/MAIN-phpunit-php8.4_D11_4x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.4_D11_4x.yml
@@ -14,7 +14,7 @@ permissions: read-all
 
 jobs:
   running-tests:
-    name: 'PHP 8.2 - Drupal 10.5.x - PostgreSQL 18'
+    name: 'PHP 8.4 - Drupal 11.4.x - PostgreSQL 18'
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout Repository'
@@ -24,8 +24,8 @@ jobs:
         with:
           directory-name: 'trpcultivate_genetics'
           modules: 'trpcultivate_genetics, trpcultivate_genomatrix, trpcultivate_genotypes, trpcultivate_qtl, trpcultivate_vcf'
-          php-version: '8.2'
-          drupal-version: '10.5.x'
+          php-version: '8.4'
+          drupal-version: '11.4.x'
           pgsql-version: '18'
           build-image: TRUE
           dockerfile: 'Dockerfile'

--- a/.github/workflows/MAIN-phpunit-php8.5_D11_4x.yml
+++ b/.github/workflows/MAIN-phpunit-php8.5_D11_4x.yml
@@ -14,7 +14,7 @@ permissions: read-all
 
 jobs:
   running-tests:
-    name: 'PHP 8.4 - Drupal 11.2.x - PostgreSQL 18'
+    name: 'PHP 8.5 - Drupal 11.4.x - PostgreSQL 18'
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout Repository'
@@ -24,8 +24,8 @@ jobs:
         with:
           directory-name: 'trpcultivate_genetics'
           modules: 'trpcultivate_genetics, trpcultivate_genomatrix, trpcultivate_genotypes, trpcultivate_qtl, trpcultivate_vcf'
-          php-version: '8.4'
-          drupal-version: '11.2.x'
+          php-version: '8.5'
+          drupal-version: '11.4.x'
           pgsql-version: '18'
           build-image: TRUE
           dockerfile: 'Dockerfile'

--- a/README.md
+++ b/README.md
@@ -70,12 +70,12 @@ The following compatibility is proven via automated testing workflows.
 [MaintainabilityBadge]: https://api.codeclimate.com/v1/badges/fddbd06df5e320f09cd9/maintainability
 [TestCoverageBadge]: https://api.codeclimate.com/v1/badges/fddbd06df5e320f09cd9/test_coverage
 
-[Grid82-106-Badge]: https://github.com/trpcultivate_genetics/trpcultivate_genetics/actions/workflows/MAIN-phpunit-php8.2_D10_6x.yml/badge.svg
-[Grid83-106-Badge]: https://github.com/trpcultivate_genetics/trpcultivate_genetics/actions/workflows/MAIN-phpunit-php8.3_D10_6x.yml/badge.svg
-[Grid83-113-Badge]: https://github.com/trpcultivate_genetics/trpcultivate_genetics/actions/workflows/MAIN-phpunit-php8.3_D11_3x.yml/badge.svg
-[Grid83-114-Badge]: https://github.com/trpcultivate_genetics/trpcultivate_genetics/actions/workflows/MAIN-phpunit-php8.3_D11_4x.yml/badge.svg
-[Grid84-106-Badge]: https://github.com/trpcultivate_genetics/trpcultivate_genetics/actions/workflows/MAIN-phpunit-php8.4_D10_6x.yml/badge.svg
-[Grid84-113-Badge]: https://github.com/trpcultivate_genetics/trpcultivate_genetics/actions/workflows/MAIN-phpunit-php8.4_D11_3x.yml/badge.svg
-[Grid84-114-Badge]: https://github.com/trpcultivate_genetics/trpcultivate_genetics/actions/workflows/MAIN-phpunit-php8.4_D11_4x.yml/badge.svg
-[Grid85-113-Badge]: https://github.com/trpcultivate_genetics/trpcultivate_genetics/actions/workflows/MAIN-phpunit-php8.5_D11_3x.yml/badge.svg
-[Grid85-114-Badge]: https://github.com/trpcultivate_genetics/trpcultivate_genetics/actions/workflows/MAIN-phpunit-php8.5_D11_4x.yml/badge.svg
+[Grid82-106-Badge]: https://github.com/TripalCultivate/TripalCultivate-Genetics/actions/workflows/MAIN-phpunit-php8.2_D10_6x.yml/badge.svg
+[Grid83-106-Badge]: https://github.com/TripalCultivate/TripalCultivate-Genetics/actions/workflows/MAIN-phpunit-php8.3_D10_6x.yml/badge.svg
+[Grid83-113-Badge]: https://github.com/TripalCultivate/TripalCultivate-Genetics/actions/workflows/MAIN-phpunit-php8.3_D11_3x.yml/badge.svg
+[Grid83-114-Badge]: https://github.com/TripalCultivate/TripalCultivate-Genetics/actions/workflows/MAIN-phpunit-php8.3_D11_4x.yml/badge.svg
+[Grid84-106-Badge]: https://github.com/TripalCultivate/TripalCultivate-Genetics/actions/workflows/MAIN-phpunit-php8.4_D10_6x.yml/badge.svg
+[Grid84-113-Badge]: https://github.com/TripalCultivate/TripalCultivate-Genetics/actions/workflows/MAIN-phpunit-php8.4_D11_3x.yml/badge.svg
+[Grid84-114-Badge]: https://github.com/TripalCultivate/TripalCultivate-Genetics/actions/workflows/MAIN-phpunit-php8.4_D11_4x.yml/badge.svg
+[Grid85-113-Badge]: https://github.com/TripalCultivate/TripalCultivate-Genetics/actions/workflows/MAIN-phpunit-php8.5_D11_3x.yml/badge.svg
+[Grid85-114-Badge]: https://github.com/TripalCultivate/TripalCultivate-Genetics/actions/workflows/MAIN-phpunit-php8.5_D11_4x.yml/badge.svg

--- a/README.md
+++ b/README.md
@@ -59,23 +59,23 @@ maintainability issues and test coverage.
 
 The following compatibility is proven via automated testing workflows.
 
-| PHP\Drupal | 10.5.x          | 10.6.x          | 11.2.x          | 11.3.x          |
-|------------|---------------------|---------------------|---------------------|---------------------|
-| **PHP8.2** | ![Grid82-105-Badge] | ![Grid82-106-Badge] |                     |                     |
-| **PHP8.3** | ![Grid83-105-Badge] | ![Grid83-106-Badge] | ![Grid83-112-Badge] | ![Grid83-113-Badge] |
-| **PHP8.4** |                     |                     | ![Grid84-112-Badge] | ![Grid84-113-Badge] |
-| **PHP8.5** |                     |                     |                     | ![Grid85-113-Badge] |
+| PHP\Drupal | 10.6.x              | 11.3.x              | 11.4.x              |
+|------------|---------------------|---------------------|---------------------|
+| **PHP8.2** | ![Grid82-106-Badge] |                     |                     |
+| **PHP8.3** | ![Grid83-106-Badge] | ![Grid83-113-Badge] | ![Grid83-114-Badge] |
+| **PHP8.4** | ![Grid84-106-Badge] | ![Grid84-113-Badge] | ![Grid84-114-Badge] |
+| **PHP8.5** |                     | ![Grid85-113-Badge] | ![Grid85-114-Badge] |
 
 [our CodeClimate project page]: https://codeclimate.com/github/TripalCultivate/TripalCultivate-Genetics
 [MaintainabilityBadge]: https://api.codeclimate.com/v1/badges/fddbd06df5e320f09cd9/maintainability
 [TestCoverageBadge]: https://api.codeclimate.com/v1/badges/fddbd06df5e320f09cd9/test_coverage
 
-[Grid82-105-Badge]: https://github.com/trpcultivate_genetics/trpcultivate_genetics/actions/workflows/MAIN-phpunit-php8.2_D10_5x.yml/badge.svg
 [Grid82-106-Badge]: https://github.com/trpcultivate_genetics/trpcultivate_genetics/actions/workflows/MAIN-phpunit-php8.2_D10_6x.yml/badge.svg
-[Grid83-105-Badge]: https://github.com/trpcultivate_genetics/trpcultivate_genetics/actions/workflows/MAIN-phpunit-php8.3_D10_5x.yml/badge.svg
 [Grid83-106-Badge]: https://github.com/trpcultivate_genetics/trpcultivate_genetics/actions/workflows/MAIN-phpunit-php8.3_D10_6x.yml/badge.svg
-[Grid83-112-Badge]: https://github.com/trpcultivate_genetics/trpcultivate_genetics/actions/workflows/MAIN-phpunit-php8.3_D11_2x.yml/badge.svg
 [Grid83-113-Badge]: https://github.com/trpcultivate_genetics/trpcultivate_genetics/actions/workflows/MAIN-phpunit-php8.3_D11_3x.yml/badge.svg
-[Grid84-112-Badge]: https://github.com/trpcultivate_genetics/trpcultivate_genetics/actions/workflows/MAIN-phpunit-php8.4_D11_2x.yml/badge.svg
+[Grid83-114-Badge]: https://github.com/trpcultivate_genetics/trpcultivate_genetics/actions/workflows/MAIN-phpunit-php8.3_D11_4x.yml/badge.svg
+[Grid84-106-Badge]: https://github.com/trpcultivate_genetics/trpcultivate_genetics/actions/workflows/MAIN-phpunit-php8.4_D10_6x.yml/badge.svg
 [Grid84-113-Badge]: https://github.com/trpcultivate_genetics/trpcultivate_genetics/actions/workflows/MAIN-phpunit-php8.4_D11_3x.yml/badge.svg
+[Grid84-114-Badge]: https://github.com/trpcultivate_genetics/trpcultivate_genetics/actions/workflows/MAIN-phpunit-php8.4_D11_4x.yml/badge.svg
 [Grid85-113-Badge]: https://github.com/trpcultivate_genetics/trpcultivate_genetics/actions/workflows/MAIN-phpunit-php8.5_D11_3x.yml/badge.svg
+[Grid85-114-Badge]: https://github.com/trpcultivate_genetics/trpcultivate_genetics/actions/workflows/MAIN-phpunit-php8.5_D11_4x.yml/badge.svg

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   ],
   "require": {
     "php": "^8.2",
-    "drupal/core": "^10.5 | ^11.2",
+    "drupal/core": "^10.6 | ^11.3",
     "tripal/tripal": "^4.0-alpha1",
     "tripalcultivate/base": "*"
   }

--- a/trpcultivate_genetics/trpcultivate_genetics.info.yml
+++ b/trpcultivate_genetics/trpcultivate_genetics.info.yml
@@ -2,7 +2,7 @@ name: 'Genetic Data API'
 type: 'module'
 description: 'Provides generic support for large-scale genotypic data, genetic maps, and QTL with importers, content pages and visualizations.'
 package: 'TripalCultivate: Genetics'
-core_version_requirement: '^10.5 || ^11.2'
+core_version_requirement: '^10.6 || ^11.3'
 dependencies:
   - 'tripal:tripal'
   - 'tripal:tripal_chado'

--- a/trpcultivate_genomatrix/trpcultivate_genomatrix.info.yml
+++ b/trpcultivate_genomatrix/trpcultivate_genomatrix.info.yml
@@ -2,7 +2,7 @@ name: Genotype Matrix
 type: module
 description: Creates a germplasm by marker matrix tool for quick visual querying of genotypic differences in smaller regions (e.g. QTL or GWAS peak).
 package: "TripalCultivate: Genetics"
-core_version_requirement: ^10.5 || ^11.2
+core_version_requirement: ^10.6 || ^11.3
 dependencies:
   - tripal:tripal
   - tripal:tripal_chado

--- a/trpcultivate_genotypes/trpcultivate_genotypes.info.yml
+++ b/trpcultivate_genotypes/trpcultivate_genotypes.info.yml
@@ -2,7 +2,7 @@ name: Genotypic Data
 type: module
 description: Expands Chado to support large-scale genotypic data.
 package: "TripalCultivate: Genetics"
-core_version_requirement: ^10.5 || ^11.2
+core_version_requirement: ^10.6 || ^11.3
 dependencies:
   - tripal:tripal
   - tripal:tripal_chado

--- a/trpcultivate_qtl/trpcultivate_qtl.info.yml
+++ b/trpcultivate_qtl/trpcultivate_qtl.info.yml
@@ -2,7 +2,7 @@ name: Genetic Maps + QTL
 type: module
 description: Expands Tripal Content pages to better support Genetic Maps + QTL.
 package: "TripalCultivate: Genetics"
-core_version_requirement: ^10.5 || ^11.2
+core_version_requirement: ^10.6 || ^11.3
 dependencies:
   - tripal:tripal
   - tripal:tripal_chado

--- a/trpcultivate_vcf/trpcultivate_vcf.info.yml
+++ b/trpcultivate_vcf/trpcultivate_vcf.info.yml
@@ -2,7 +2,7 @@ name: Variant Call Format (VCF)
 type: module
 description: Creates a tool for easily filtering VCF files and converting to different formats.
 package: "TripalCultivate: Genetics"
-core_version_requirement: ^10.5 || ^11.2
+core_version_requirement: ^10.6 || ^11.3
 dependencies:
   - tripal:tripal
   - tripal:tripal_chado


### PR DESCRIPTION
**Issue #49**

## Motivation

<!-- This can usually be copied from the issue. Please do not just say, go see issue but instead copy the relevant details here. -->
As Drupal released version 11.4 on June 15, 2026, we need to add support for 11.4 for this module. And the security support for 11.2.x and 10.5.x has ended so we need to remove those versions.

## What does this PR do?
<!-- *Please describe each things this PR does. For example, a PR may 1) solve a specific bug, 2) create an auomated test to ensure it doesn't return.* -->

- [x]  Add support for drupal 11.4
- [x]  Remove support for drupal 11.2 and 10.5

## Testing

### Automated Testing
<!-- *Please describe each automated test this PR creates and provide a list of the assertions it makes using casual language.*
*Do not just say things like "asserts the array is not empty" but rather say "Ensures that the return value of method X with these parameters is not an empty array".*

ClassName->testSpecificBug: tests this specific bug -->
No new automated testing implemented.

### Manual Testing
<!-- *Describe in detail how someone should manually test this functionality.*
*Make sure to include whether they need to build a docker from scratch, create any records, etc.* -->

1. Checkout this branch locally and start a docker.
2. Confirm that devcontainer builds properly on drupal 11.4 and open the webpage in the browser to confirm versions.
3. Confirm that all the automated tests are passing both locally and on the remote branch.
<img width="678" height="138" alt="Screenshot 2026-06-29 at 11 37 44 AM" src="https://github.com/user-attachments/assets/9f21892e-c920-41fc-bb24-2fc095d6fe16" />

<img width="347" height="507" alt="Screenshot 2026-06-29 at 11 37 05 AM" src="https://github.com/user-attachments/assets/8fa70104-8034-4fba-bfb8-f47c544f7671" />
