### PR TITLE
G0.51 Replaces the deprecated organism API method calls

### DIFF
--- a/trpcultivate_genotypes/src/GenotypesLoader/GenotypesLoaderPluginBase.php
+++ b/trpcultivate_genotypes/src/GenotypesLoader/GenotypesLoaderPluginBase.php
@@ -4,8 +4,10 @@ namespace Drupal\trpcultivate_genotypes\GenotypesLoader;
 
 use Drupal\Component\Plugin\PluginBase;
 use Drupal\tripal\Services\TripalLogger;
+use Drupal\tripal_chado\ChadoBuddy\PluginManagers\ChadoBuddyPluginManager;
 use Drupal\tripal_chado\Database\ChadoConnection;
-use \Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\tripal_chado\Plugin\ChadoBuddy\ChadoOrganismBuddy;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -93,6 +95,20 @@ abstract class GenotypesLoaderPluginBase extends PluginBase implements Genotypes
   protected $connection;
 
   /**
+   * The Chado Buddy service manager.
+   *
+   * @var Drupal\tripal_chado\ChadoBuddy\PluginManagers\ChadoBuddyPluginManager
+   */
+  protected ChadoBuddyPluginManager $buddy_manager;
+
+  /**
+   * An instance of the organism Chado Buddy.
+   *
+   * @var Drupal\tripal_chado\Plugin\ChadoBuddy\ChadoOrganismBuddy
+   */
+  protected ChadoOrganismBuddy $organism_buddy;
+
+  /**
    * The service for retreiving configuration values.
    *
    * @var \Drupal\Core\Config\ConfigFactoryInterface
@@ -110,7 +126,7 @@ abstract class GenotypesLoaderPluginBase extends PluginBase implements Genotypes
    * @param array $configuration
    * @param string $plugin_id
    * @param mixed $plugin_definition
-   *
+   * 
    * @return static
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
@@ -120,6 +136,7 @@ abstract class GenotypesLoaderPluginBase extends PluginBase implements Genotypes
       $plugin_definition,
       $container->get('tripal.logger'),
       $container->get('tripal_chado.database'),
+      $container->get('tripal_chado.chado_buddy'),
       $container->get('config.factory')
     );
   }
@@ -137,12 +154,24 @@ abstract class GenotypesLoaderPluginBase extends PluginBase implements Genotypes
    * @param mixed $plugin_definition
    * @param Drupal\tripal\Services\TripalLogger $logger
    * @param Drupal\tripal_chado\Database\ChadoConnection $connection
+   * @param Drupal\tripal_chado\ChadoBuddy\PluginManagers\ChadoBuddyPluginManager $buddy_manager
+   *   The ChadoBuddy plugin manager.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, TripalLogger $logger, ChadoConnection $connection, ConfigFactoryInterface $config_factory) {
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    TripalLogger $logger,
+    ChadoConnection $connection,
+    ChadoBuddyPluginManager $buddy_manager,
+    ConfigFactoryInterface $config_factory,
+    ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
 
     $this->logger = $logger;
     $this->connection = $connection;
+    $this->buddy_manager = $buddy_manager;
+    $this->organism_buddy = $this->buddy_manager->createInstance('chado_organism_buddy', []);
     $this->config_factory = $config_factory;
   }
 
@@ -326,7 +355,7 @@ abstract class GenotypesLoaderPluginBase extends PluginBase implements Genotypes
         $organism_name = array_shift($current_line);
         if (!empty($organism_name)) {
           // Grab the organism ID using the organism name and genus supplied in the samples file
-          $organism_array = chado_get_organism_id_from_scientific_name($organism_name);
+          $organism_array = $this->organism_buddy->getOrganismFromScientificName($organism_name);
           //print_r($organism_array);
           if (!$organism_array) {
             throw new \Exception(
@@ -340,7 +369,7 @@ abstract class GenotypesLoaderPluginBase extends PluginBase implements Genotypes
               t("ERROR: Retrieved more than one organism ID for \"@organism_name\" when only 1 was expected.", ['@organism_name' => $organism_name])
             );
           }
-          $organism_id = $organism_array[0];
+          $organism_id = $organism_array[0]->getValue('organism.organism_id');
         }
       }
 

--- a/trpcultivate_genotypes/tests/src/Functional/GenotypesLoader/GenotypesLoaderBasePluginTest.php
+++ b/trpcultivate_genotypes/tests/src/Functional/GenotypesLoader/GenotypesLoaderBasePluginTest.php
@@ -43,6 +43,9 @@ class GenotypesLoaderBasePluginTest extends ChadoTestBrowserBase {
     // Open connection to Chado
     $connection = $this->createTestSchema(ChadoTestBrowserBase::PREPARE_TEST_CHADO);
 
+    // Buddy Manager.
+    $buddy_manager = \Drupal::getContainer()->get('tripal_chado.chado_buddy');
+
     // Config factory mock.
     $config_factory = $this->createMock('Drupal\Core\Config\ConfigFactoryInterface');
 
@@ -51,7 +54,15 @@ class GenotypesLoaderBasePluginTest extends ChadoTestBrowserBase {
     $configuration = [];
     $plugin_definition = [];
     $logger = \Drupal::service('tripal.logger');
-    $plugin = new GenotypesLoaderFakePlugin($configuration,"fake_genotypes_loader",$plugin_definition,$logger,$connection,$config_factory);
+    $plugin = new GenotypesLoaderFakePlugin(
+      $configuration,
+      "fake_genotypes_loader",
+      $plugin_definition,
+      $logger,
+      $connection,
+      $buddy_manager,
+      $config_factory
+    );
     $this->assertIsObject($plugin, 'Unable to create a Plugin');
     $this->assertInstanceOf(GenotypesLoaderInterface::class, $plugin,"Returned object is not an instance of GenotypesLoaderInterface.");
 

--- a/trpcultivate_genotypes/tests/src/Kernel/GenotypesLoader/GenotypesLoaderProcessSamplesTest.php
+++ b/trpcultivate_genotypes/tests/src/Kernel/GenotypesLoader/GenotypesLoaderProcessSamplesTest.php
@@ -87,8 +87,20 @@ class GenotypesLoaderProcessSamplesTest extends ChadoTestKernelBase {
 		// Configuration should be any key value pairs specific to Genotypes Loader plugin
 		$configuration = [];
 		$plugin_definition = [];
+
+		// Buddy Manager.
+    $buddy_manager = \Drupal::getContainer()->get('tripal_chado.chado_buddy');
+
 		$logger = \Drupal::service('tripal.logger');
-		$this->plugin = new GenotypesLoaderFakePlugin($configuration,"fake_genotypes_loader",$plugin_definition,$logger,$this->connection,$config_factory);
+		$this->plugin = new GenotypesLoaderFakePlugin(
+			$configuration,
+			"fake_genotypes_loader",
+			$plugin_definition,
+			$logger,
+			$this->connection,
+			$buddy_manager,
+			$config_factory
+		);
 		$this->assertIsObject($this->plugin, 'Unable to create a Plugin');
 		$this->assertInstanceOf(GenotypesLoaderInterface::class, $this->plugin,"Returned object is not an instance of GenotypesLoaderInterface.");
 	}


### PR DESCRIPTION
**Issue #51**

## Motivation

<!-- This can usually be copied from the issue. Please do not just say, go see issue but instead copy the relevant details here. -->
After deprecating the organism API methods on tripal, the automated tests are failing in this module due to those organism api method calls. We need to replace those with the organism buddy methods as indicated in the deprecation notices.


## What does this PR do?
Replaces the Organism API method calls with the ChadoOrganismBuddy methods.
1. Replaces `chado_get_organism_id_from_scientific_name()` method call with ChadoOrganismBuddy getOrganismFromScientificName() method in `GenotypesLoaderPluginBase`

## Testing

### Automated Testing
No new tests have been added. However, all the existing automated tests should be passing.
